### PR TITLE
fix: register LSP commands with Monaco for code action execution

### DIFF
--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -123,6 +123,14 @@ export function useLexTestBridge({
         if (!model) return []
         return monaco.editor.getModelMarkers({ resource: model.uri })
       },
+      setCursor: (line: number, col: number) => {
+        const editorInstance = getActiveEditorInstance()
+        if (!editorInstance) return false
+        editorInstance.setPosition({ lineNumber: line, column: col })
+        // Also reveal the position to be safe
+        editorInstance.revealPosition({ lineNumber: line, column: col })
+        return true
+      },
     }
     window.lexTest = api
     return () => {

--- a/src/lsp/providers/code_action.ts
+++ b/src/lsp/providers/code_action.ts
@@ -1,117 +1,155 @@
-import * as monaco from 'monaco-editor';
-import { ProtocolConnection, CodeActionParams, CodeActionRequest, CodeAction as LspCodeAction, Command, TextEdit, Diagnostic } from 'vscode-languageserver-protocol/browser';
+import * as monaco from 'monaco-editor'
+import {
+  ProtocolConnection,
+  CodeActionParams,
+  CodeActionRequest,
+  CodeAction as LspCodeAction,
+  Command,
+  TextEdit,
+  Diagnostic,
+  ExecuteCommandRequest,
+} from 'vscode-languageserver-protocol/browser'
+
+// Track registered commands to avoid duplicates
+const registeredCommands = new Set<string>()
+
+function registerLspCommand(commandId: string, connection: ProtocolConnection) {
+  if (registeredCommands.has(commandId)) return
+  registeredCommands.add(commandId)
+
+  monaco.editor.registerCommand(commandId, (_accessor, ...args) => {
+    // Forward command execution to LSP server
+    connection
+      .sendRequest(ExecuteCommandRequest.type, {
+        command: commandId,
+        arguments: args,
+      })
+      .catch((err) => {
+        console.error(`[LSP] Failed to execute command ${commandId}:`, err)
+      })
+  })
+}
 
 export function registerCodeActionProvider(languageId: string, connection: ProtocolConnection) {
-    monaco.languages.registerCodeActionProvider(languageId, {
-        provideCodeActions: async (
-            model: monaco.editor.ITextModel,
-            range: monaco.Range,
-            context: monaco.languages.CodeActionContext
-        ) => {
-            if (!connection) return { actions: [], dispose: () => {} };
+  monaco.languages.registerCodeActionProvider(languageId, {
+    provideCodeActions: async (
+      model: monaco.editor.ITextModel,
+      range: monaco.Range,
+      context: monaco.languages.CodeActionContext
+    ) => {
+      if (!connection) return { actions: [], dispose: () => {} }
 
-            const params: CodeActionParams = {
-                textDocument: { uri: model.uri.toString() },
-                range: {
-                    start: { line: range.startLineNumber - 1, character: range.startColumn - 1 },
-                    end: { line: range.endLineNumber - 1, character: range.endColumn - 1 }
-                },
-                context: {
-                    diagnostics: context.markers.map((marker: monaco.editor.IMarkerData) => ({
-                        range: {
-                            start: { line: marker.startLineNumber - 1, character: marker.startColumn - 1 },
-                            end: { line: marker.endLineNumber - 1, character: marker.endColumn - 1 }
-                        },
-                        message: marker.message,
-                        severity: marker.severity === monaco.MarkerSeverity.Error ? 1 :
-                                  marker.severity === monaco.MarkerSeverity.Warning ? 2 :
-                                  marker.severity === monaco.MarkerSeverity.Info ? 3 : 4,
-                        code: typeof marker.code === 'string' ? marker.code : undefined,
-                        source: marker.source
-                    }))
-                }
-            };
+      const params: CodeActionParams = {
+        textDocument: { uri: model.uri.toString() },
+        range: {
+          start: { line: range.startLineNumber - 1, character: range.startColumn - 1 },
+          end: { line: range.endLineNumber - 1, character: range.endColumn - 1 },
+        },
+        context: {
+          diagnostics: context.markers.map((marker: monaco.editor.IMarkerData) => ({
+            range: {
+              start: { line: marker.startLineNumber - 1, character: marker.startColumn - 1 },
+              end: { line: marker.endLineNumber - 1, character: marker.endColumn - 1 },
+            },
+            message: marker.message,
+            severity:
+              marker.severity === monaco.MarkerSeverity.Error
+                ? 1
+                : marker.severity === monaco.MarkerSeverity.Warning
+                  ? 2
+                  : marker.severity === monaco.MarkerSeverity.Info
+                    ? 3
+                    : 4,
+            code: typeof marker.code === 'string' ? marker.code : undefined,
+            source: marker.source,
+          })),
+        },
+      }
 
-            try {
-                const result = await connection.sendRequest(CodeActionRequest.type, params);
-                if (!result) return { actions: [], dispose: () => {} };
+      try {
+        const result = await connection.sendRequest(CodeActionRequest.type, params)
+        if (!result) return { actions: [], dispose: () => {} }
 
-                const actions: monaco.languages.CodeAction[] = [];
-                
-                for (const item of result) {
-                    if (Command.is(item)) {
-                        actions.push({
-                            title: item.title,
-                            command: {
-                                id: item.command,
-                                title: item.title,
-                                arguments: item.arguments
-                            },
-                            kind: 'quickfix'
-                        });
-                    } else {
-                        const action = item as LspCodeAction;
-                        const monacoAction: monaco.languages.CodeAction = {
-                            title: action.title,
-                            kind: action.kind,
-                            diagnostics: action.diagnostics ? action.diagnostics.map((d: Diagnostic) => ({
-                                startLineNumber: d.range.start.line + 1,
-                                startColumn: d.range.start.character + 1,
-                                endLineNumber: d.range.end.line + 1,
-                                endColumn: d.range.end.character + 1,
-                                message: d.message,
-                                severity: monaco.MarkerSeverity.Error
-                            })) : undefined,
-                            isPreferred: action.isPreferred,
-                            disabled: action.disabled ? action.disabled.reason : undefined
-                        };
+        const actions: monaco.languages.CodeAction[] = []
 
-                        if (action.edit) {
-                            monacoAction.edit = {
-                                edits: []
-                            };
-                            if (action.edit.changes) {
-                                for (const [uri, edits] of Object.entries(action.edit.changes)) {
-                                    const resource = monaco.Uri.parse(uri);
-                                    for (const edit of (edits as TextEdit[])) {
-                                        monacoAction.edit.edits.push({
-                                            resource: resource,
-                                            textEdit: {
-                                                range: {
-                                                    startLineNumber: edit.range.start.line + 1,
-                                                    startColumn: edit.range.start.character + 1,
-                                                    endLineNumber: edit.range.end.line + 1,
-                                                    endColumn: edit.range.end.character + 1
-                                                },
-                                                text: edit.newText
-                                            },
-                                            versionId: undefined
-                                        });
-                                    }
-                                }
-                            }
-                        }
-
-                        if (action.command) {
-                            monacoAction.command = {
-                                id: action.command.command,
-                                title: action.command.title,
-                                arguments: action.command.arguments
-                            };
-                        }
-
-                        actions.push(monacoAction);
-                    }
-                }
-
-                return {
-                    actions: actions,
-                    dispose: () => {}
-                };
-            } catch (e) {
-                console.error('[LSP] CodeAction failed:', e);
-                return { actions: [], dispose: () => {} };
+        for (const item of result) {
+          if (Command.is(item)) {
+            actions.push({
+              title: item.title,
+              command: {
+                id: item.command,
+                title: item.title,
+                arguments: item.arguments,
+              },
+              kind: 'quickfix',
+            })
+          } else {
+            const action = item as LspCodeAction
+            const monacoAction: monaco.languages.CodeAction = {
+              title: action.title,
+              kind: action.kind,
+              diagnostics: action.diagnostics
+                ? action.diagnostics.map((d: Diagnostic) => ({
+                    startLineNumber: d.range.start.line + 1,
+                    startColumn: d.range.start.character + 1,
+                    endLineNumber: d.range.end.line + 1,
+                    endColumn: d.range.end.character + 1,
+                    message: d.message,
+                    severity: monaco.MarkerSeverity.Error,
+                  }))
+                : undefined,
+              isPreferred: action.isPreferred,
+              disabled: action.disabled ? action.disabled.reason : undefined,
             }
+
+            if (action.edit) {
+              monacoAction.edit = {
+                edits: [],
+              }
+              if (action.edit.changes) {
+                for (const [uri, edits] of Object.entries(action.edit.changes)) {
+                  const resource = monaco.Uri.parse(uri)
+                  for (const edit of edits as TextEdit[]) {
+                    monacoAction.edit.edits.push({
+                      resource: resource,
+                      textEdit: {
+                        range: {
+                          startLineNumber: edit.range.start.line + 1,
+                          startColumn: edit.range.start.character + 1,
+                          endLineNumber: edit.range.end.line + 1,
+                          endColumn: edit.range.end.character + 1,
+                        },
+                        text: edit.newText,
+                      },
+                      versionId: undefined,
+                    })
+                  }
+                }
+              }
+            }
+
+            if (action.command) {
+              // Register the LSP command with Monaco so it can be executed
+              registerLspCommand(action.command.command, connection)
+              monacoAction.command = {
+                id: action.command.command,
+                title: action.command.title,
+                arguments: action.command.arguments,
+              }
+            }
+
+            actions.push(monacoAction)
+          }
         }
-    });
+
+        return {
+          actions: actions,
+          dispose: () => {},
+        }
+      } catch (e) {
+        console.error('[LSP] CodeAction failed:', e)
+        return { actions: [], dispose: () => {} }
+      }
+    },
+  })
 }

--- a/tests/e2e/spellcheck.spec.ts
+++ b/tests/e2e/spellcheck.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { openFixture, launchApp } from './helpers'
+import path from 'path'
+import * as fs from 'fs/promises'
 
 test.describe('Spellcheck', () => {
   test('should show diagnostics for misspelled words and support language switching', async () => {
@@ -136,6 +138,147 @@ test.describe('Spellcheck', () => {
         .toMatchObject({ enabled: true, language: 'fr_FR' })
     } finally {
       await electronApp.close()
+    }
+  })
+
+  test('successfully adds words to dictionary', async () => {
+    // We need a unique data dir for this test to verify persistence
+    // "lex-lsp" uses LEX_TEST_DATA_DIR to override the data directory
+    // We can pass this env var to the app
+    const testDataDir = path.resolve(
+      process.cwd(),
+      '..',
+      'target',
+      'e2e-data',
+      `spell-${Date.now()}`
+    )
+    await fs.mkdir(testDataDir, { recursive: true })
+
+    console.log(`Using test data dir: ${testDataDir}`)
+
+    const electronApp = await launchApp({
+      env: {
+        LEX_LSP_PATH: path.resolve('resources', 'lex-lsp'), // Explicitly use our copied binary
+        LEX_TEST_DATA_DIR: testDataDir,
+        // Disable welcome logic to speed up
+        LEX_DISABLE_PERSISTENCE: '1',
+      },
+    })
+    const page = await electronApp.firstWindow()
+    page.on('console', (msg) => console.log('renderer:', msg.text()))
+    await page.waitForLoadState('domcontentloaded')
+
+    try {
+      // 1. Enable spellcheck
+      await page.evaluate(async () => {
+        await (window as any).ipcRenderer.setSpellcheckSettings({
+          enabled: true,
+          language: 'en_US',
+        })
+      })
+
+      // 2. Open fixture
+      await openFixture(page, 'spellcheck-test.lex')
+      const editor = page.locator('.monaco-editor').first()
+      await expect(editor).toBeVisible()
+
+      // 3. Type a misspelled word
+      const misspelled = 'foobarbaz' // very unlikely to be in dictionary
+      await editor.click()
+      // Use keyboard to ensure events fire
+      await page.keyboard.press('Control+End') // Go to end
+      await page.keyboard.press('Enter')
+      await page.keyboard.type(misspelled)
+      await page.keyboard.type(' ') // Trigger check
+
+      // Helper to wait for marker
+      const waitForMarker = async (word: string, exists: boolean) => {
+        await expect
+          .poll(
+            async () => {
+              const markers = await page.evaluate(() => (window as any).lexTest?.getMarkers() || [])
+              return markers.some((m: any) => m.message.includes(`Unknown word: ${word}`))
+            },
+            { timeout: 10000, message: `Waiting for marker "${word}" to be ${exists}` }
+          )
+          .toBe(exists)
+      }
+
+      // Check marker exists
+      await waitForMarker(misspelled, true)
+
+      // Log cursor and markers
+      await page.evaluate(async () => {
+        const markers = (window as any).lexTest?.getMarkers() || []
+        console.log('[Test Debug] Markers:', markers)
+
+        const marker = markers.find((m: any) => m.message.includes('foobarbaz'))
+        if (marker) {
+          console.log('[Test Debug] Moving to marker:', marker)
+          // Use setCursor helper we just added
+          const success = (window as any).lexTest?.setCursor(
+            marker.startLineNumber,
+            marker.startColumn + 1
+          )
+          console.log('[Test Debug] setCursor result:', success)
+        } else {
+          console.error('[Test Debug] Marker not found!')
+        }
+      })
+
+      // Trigger standard Quick Fix menu (Cmd+. or Ctrl+.)
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+      await page.keyboard.press(`${modifier}+.`)
+
+      // Wait for the quick fix menu to appear
+      await page.waitForSelector('.context-view-block', { state: 'visible', timeout: 10000 })
+
+      // Wait for widget - look for partial match since title is "Add 'foobarbaz' to dictionary"
+      const widget = page.locator('.monaco-list-row').filter({ hasText: 'to dictionary' })
+      await expect(widget).toBeVisible({ timeout: 10000 })
+
+      // 5. Select "Add to dictionary" - use keyboard as Monaco has pointer-blocking overlay
+      // Navigate to the "Add to dictionary" option using arrow keys
+      // For an unknown word like "foobarbaz", there may be no suggestions, so it might be first
+      // Use ArrowDown to navigate through items until we find the right one, then Enter
+      // Or use End to go to last item directly
+      for (let i = 0; i < 5; i++) {
+        // Check if the "to dictionary" item is focused
+        const focusedItem = await page
+          .locator('.monaco-list-row.focused')
+          .textContent()
+          .catch(() => '')
+        if (focusedItem && focusedItem.includes('to dictionary')) {
+          break
+        }
+        await page.keyboard.press('ArrowDown')
+        await page.waitForTimeout(50)
+      }
+      await page.keyboard.press('Enter')
+
+      // 6. Verify marker disappears
+      await waitForMarker(misspelled, false)
+
+      // 7. Verify file on disk
+      const customDicPath = path.join(testDataDir, 'dictionaries', 'custom.dic')
+      // Wait a bit for file write
+      await expect
+        .poll(async () => {
+          try {
+            return await fs.readFile(customDicPath, 'utf8')
+          } catch {
+            return ''
+          }
+        })
+        .toContain(misspelled)
+    } finally {
+      await electronApp.close()
+      // Cleanup
+      try {
+        await fs.rm(testDataDir, { recursive: true, force: true })
+      } catch (e) {
+        console.error('Failed to cleanup test data dir:', e)
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary
- Fix LSP code action commands (like "Add to dictionary") not executing when selected in Monaco's quick fix menu
- Add `registerLspCommand` function that registers LSP commands with Monaco's command service and forwards execution to the LSP server via `workspace/executeCommand`
- Update e2e test to use keyboard navigation instead of clicks to work around Monaco's pointer-blocking overlay

## Test plan
- [x] Open a .lex file with misspelled words
- [x] Verify spelling diagnostics appear (squiggly underlines)
- [x] Position cursor on misspelled word and trigger quick fix (Cmd+. or Ctrl+.)
- [x] Select "Add to dictionary" action
- [x] Verify the word is added and diagnostic disappears
- [x] Verify word persists in custom dictionary file

🤖 Generated with [Claude Code](https://claude.com/claude-code)