### PR TITLE
chore: bump lex-lsp to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lexed",
   "productName": "LexEd",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "LexEd editor for Lex",
   "author": {
     "name": "Arthur Debert",

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,4 +1,4 @@
 {
-  "lex-lsp": "v0.2.9",
+  "lex-lsp": "v0.3.0",
   "lex-lsp-repo": "lex-fmt/editors"
 }


### PR DESCRIPTION
## Summary

- Bump lex-lsp from v0.2.9 to v0.3.0
- Bump app version to 0.4.9
- Picks up verbatim indentation fix and subject field support

## Test plan

- [x] 24 e2e tests pass (3 spellcheck tests flaky — pre-existing, also fail on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)