### PR TITLE
chore: bump lex-lsp to v0.3.3

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,4 +1,4 @@
 {
-  "lex-lsp": "v0.3.2",
+  "lex-lsp": "v0.3.3",
   "lex-lsp-repo": "lex-fmt/editors"
 }


### PR DESCRIPTION
## Summary
- Bumps lex-lsp dependency to v0.3.3
- Fixes colon trigger firing outside verbatim context (e.g. `Ideas:` no longer triggers spurious completions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)