### PR TITLE
Add E2E test infrastructure: LSP readiness signal, helpers, config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
-  timeout: 30000,
-  retries: 0,
+  timeout: 60000,
+  retries: 1,
   workers: 1, // Electron doesn't support parallel execution well
   globalSetup: './tests/e2e/global-setup.ts',
   use: {
     trace: 'on-first-retry',
   },
-});
+})

--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -124,6 +124,7 @@ export function useLexTestBridge({
         if (!model) return []
         return monaco.editor.getModelMarkers({ resource: model.uri })
       },
+      isLspReady: () => Boolean(window.__lexLspReady),
       isSpellcheckReady: () => spellcheckService.isReady(),
       recheckSpelling: () => {
         const target = activePaneId ?? panesRef.current[0]?.id ?? null

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -275,6 +275,7 @@ export class LspClient {
 
       await this.connection.sendNotification(InitializedNotification.type, {})
       log.info('[LspClient] Initialized')
+      window.__lexLspReady = true
       window.dispatchEvent(new CustomEvent('lexed:lsp-ready'))
 
       // Reset retry count on successful connection
@@ -362,6 +363,7 @@ export class LspClient {
 
     this.connection = null
     this.readyPromise = null
+    window.__lexLspReady = false
 
     if (this.retryCount < this.maxRetries) {
       const delay = this.baseRetryDelay * Math.pow(2, this.retryCount)
@@ -382,6 +384,7 @@ export class LspClient {
 
   public dispose() {
     this.isDisposed = true
+    window.__lexLspReady = false
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 /// <reference types="vite/client" />
 
 interface Window {
+  __lexLspReady?: boolean
   ipcRenderer: {
     on(channel: string, func: (...args: unknown[]) => void): () => void
     off(channel: string, func: (...args: unknown[]) => void): void
@@ -108,5 +109,9 @@ interface Window {
     getLastFormattingRequest?: () => { type: 'document' | 'range'; params: unknown } | null
     notifyFormattingRequest?: (payload: { type: 'document' | 'range'; params: unknown }) => void
     getMarkers?: () => unknown[]
+    isLspReady?: () => boolean
+    isSpellcheckReady?: () => boolean
+    recheckSpelling?: () => boolean
+    setCursor?: (line: number, col: number) => boolean
   }
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -2,12 +2,12 @@ import { _electron as electron, type Page } from '@playwright/test'
 import path from 'node:path'
 import type { ProcessEnv } from 'node:process'
 
-type LaunchOptions = {
+export type AppLaunchOptions = {
   extraArgs?: string[]
   env?: Record<string, string | undefined>
 }
 
-export async function launchApp(options: LaunchOptions = {}) {
+export async function launchApp(options: AppLaunchOptions = {}) {
   const { extraArgs = [], env: envOverrides = {} } = options
   const useBuiltRenderer = process.env.LEX_E2E_USE_BUILD === '1'
   const devServerUrl =

--- a/tests/e2e/lib/app.ts
+++ b/tests/e2e/lib/app.ts
@@ -19,8 +19,13 @@ export type AppFixtures = {
   launchOptions: AppLaunchOptions
 }
 
+const defaultLaunchOptions: AppLaunchOptions = {
+  env: { LEX_DISABLE_PERSISTENCE: '1' },
+}
+
 export const test = base.extend<AppFixtures>({
-  launchOptions: [({}, use) => use({}), { option: true }], // eslint-disable-line no-empty-pattern
+  // eslint-disable-next-line no-empty-pattern
+  launchOptions: [({}, use) => use(defaultLaunchOptions), { option: true }],
   electronApp: async ({ launchOptions }, use) => {
     const app = await launchApp(launchOptions)
     await use(app)

--- a/tests/e2e/lib/app.ts
+++ b/tests/e2e/lib/app.ts
@@ -1,0 +1,36 @@
+import { test as base, type ElectronApplication, type Page } from '@playwright/test'
+import { launchApp, type AppLaunchOptions } from '../helpers'
+
+/**
+ * Playwright fixture that provides a fresh Electron app + page per test,
+ * with guaranteed cleanup regardless of test outcome.
+ *
+ * Usage:
+ *   import { test, expect } from './lib'
+ *
+ *   test('my test', async ({ electronApp, page }) => { ... })
+ *
+ * To customize launch options for a describe block:
+ *   test.use({ launchOptions: { env: { LEX_DISABLE_PERSISTENCE: '0' } } })
+ */
+export type AppFixtures = {
+  electronApp: ElectronApplication
+  page: Page
+  launchOptions: AppLaunchOptions
+}
+
+export const test = base.extend<AppFixtures>({
+  launchOptions: [({}, use) => use({}), { option: true }], // eslint-disable-line no-empty-pattern
+  electronApp: async ({ launchOptions }, use) => {
+    const app = await launchApp(launchOptions)
+    await use(app)
+    await app.close()
+  },
+  page: async ({ electronApp }, use) => {
+    const page = await electronApp.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await use(page)
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/tests/e2e/lib/assertions.ts
+++ b/tests/e2e/lib/assertions.ts
@@ -1,0 +1,137 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+type MarkerMatch = {
+  message?: string | RegExp
+  severity?: 'error' | 'warning' | 'info' | 'hint'
+  startLineNumber?: number
+  source?: string
+}
+
+const SEVERITY_MAP = { error: 8, warning: 4, info: 2, hint: 1 } as const
+
+function matchesMarker(
+  actual: { message: string; severity: number; startLineNumber: number; source: string },
+  match: MarkerMatch
+): boolean {
+  if (match.message instanceof RegExp) {
+    if (!match.message.test(actual.message)) return false
+  } else if (match.message !== undefined) {
+    if (!actual.message.includes(match.message)) return false
+  }
+  if (match.severity !== undefined && actual.severity !== SEVERITY_MAP[match.severity]) return false
+  if (match.startLineNumber !== undefined && actual.startLineNumber !== match.startLineNumber)
+    return false
+  if (match.source !== undefined && actual.source !== match.source) return false
+  return true
+}
+
+/**
+ * Assert on the markers (diagnostics) attached to the active editor model.
+ * Uses the lexTest bridge to read markers directly from Monaco's API,
+ * not from DOM squiggly classes.
+ *
+ * @param expected - Array of partial marker objects to match against.
+ *   Each entry is matched independently; order doesn't matter.
+ *   Pass an empty array to assert no markers exist.
+ */
+export async function expectMarkers(page: Page, expected: MarkerMatch[], { timeout = 10000 } = {}) {
+  const getMarkers = () =>
+    page.evaluate(() => {
+      const markers = (window as any).lexTest?.getMarkers?.() ?? []
+      return markers.map((m: any) => ({
+        message: m.message,
+        severity: m.severity,
+        startLineNumber: m.startLineNumber,
+        source: m.source,
+      }))
+    })
+
+  if (expected.length === 0) {
+    await expect
+      .poll(getMarkers, { timeout, message: 'Waiting for markers to clear' })
+      .toHaveLength(0)
+    return
+  }
+
+  // Poll until all expected markers are found.
+  // We serialize the expected matchers to pass into waitForFunction,
+  // but since MarkerMatch can contain RegExp, we poll from the Node side.
+  await expect
+    .poll(
+      async () => {
+        const markers = await getMarkers()
+        return expected.every((exp) => markers.some((m: any) => matchesMarker(m, exp)))
+      },
+      { timeout, message: 'Waiting for expected markers' }
+    )
+    .toBe(true)
+}
+
+/**
+ * Assert on the last formatting request captured by the test bridge.
+ * Waits for __lexLastFormattingRequest to be set, then deeply matches.
+ */
+export async function expectFormattingRequest(
+  page: Page,
+  expected: { type?: 'document' | 'range'; options?: Record<string, unknown> },
+  { timeout = 10000 } = {}
+) {
+  await page.waitForFunction(() => Boolean((window as any).__lexLastFormattingRequest), null, {
+    timeout,
+  })
+  const request = await page.evaluate(() => (window as any).__lexLastFormattingRequest)
+  if (expected.type !== undefined) {
+    expect(request?.type).toBe(expected.type)
+  }
+  if (expected.options !== undefined) {
+    expect(request?.params?.options).toMatchObject(expected.options)
+  }
+  return request
+}
+
+/**
+ * Assert the active editor's model value equals or contains the expected text.
+ * Reads via the lexTest bridge (model API), not DOM text content.
+ */
+export async function expectEditorValue(
+  page: Page,
+  expected: string | RegExp,
+  { exact = false, timeout = 10000 } = {}
+) {
+  if (expected instanceof RegExp) {
+    await expect
+      .poll(() => page.evaluate(() => (window as any).lexTest?.getActiveEditorValue() ?? ''), {
+        timeout,
+        message: 'Waiting for editor value to match pattern',
+      })
+      .toMatch(expected)
+  } else if (exact) {
+    await expect
+      .poll(() => page.evaluate(() => (window as any).lexTest?.getActiveEditorValue() ?? ''), {
+        timeout,
+        message: 'Waiting for exact editor value',
+      })
+      .toBe(expected)
+  } else {
+    await expect
+      .poll(() => page.evaluate(() => (window as any).lexTest?.getActiveEditorValue() ?? ''), {
+        timeout,
+        message: 'Waiting for editor value to contain text',
+      })
+      .toContain(expected)
+  }
+}
+
+/**
+ * Assert that a toast notification appeared with the given text.
+ */
+export async function expectToast(page: Page, text: string | RegExp, timeout = 10000) {
+  const toastLocator = page.locator('[data-sonner-toast]')
+  await expect(toastLocator).toBeVisible({ timeout })
+  if (text instanceof RegExp) {
+    await expect(toastLocator).toHaveText(text)
+  } else {
+    await expect(toastLocator).toContainText(text)
+  }
+}

--- a/tests/e2e/lib/assertions.ts
+++ b/tests/e2e/lib/assertions.ts
@@ -70,13 +70,17 @@ export async function expectMarkers(page: Page, expected: MarkerMatch[], { timeo
 
 /**
  * Assert on the last formatting request captured by the test bridge.
- * Waits for __lexLastFormattingRequest to be set, then deeply matches.
+ * Resets the captured request first, then waits for a new one to arrive.
  */
 export async function expectFormattingRequest(
   page: Page,
   expected: { type?: 'document' | 'range'; options?: Record<string, unknown> },
   { timeout = 10000 } = {}
 ) {
+  await page.evaluate(() => {
+    ;(window as any).lexTest?.resetFormattingRequest?.()
+    ;(window as any).__lexLastFormattingRequest = null
+  })
   await page.waitForFunction(() => Boolean((window as any).__lexLastFormattingRequest), null, {
     timeout,
   })

--- a/tests/e2e/lib/index.ts
+++ b/tests/e2e/lib/index.ts
@@ -1,0 +1,10 @@
+export { test, expect, type AppFixtures } from './app'
+export type { AppLaunchOptions } from '../helpers'
+export { waitForLsp, waitForEditor, waitForEditorContent, waitForSpellcheck } from './wait'
+export * as loc from './locators'
+export {
+  expectMarkers,
+  expectFormattingRequest,
+  expectEditorValue,
+  expectToast,
+} from './assertions'

--- a/tests/e2e/lib/locators.ts
+++ b/tests/e2e/lib/locators.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test'
+
+// -- Editor --
+
+export const editor = (page: Page) => page.locator('.monaco-editor').first()
+
+// -- Toolbar buttons --
+// These use title-based selectors today; as data-testid attributes are added
+// in a follow-up PR, update these one place instead of every test.
+
+export const formatButton = (page: Page) => page.locator('button[title="Format Document"]')
+export const settingsButton = (page: Page) => page.locator('button[title="Settings"]')
+export const previewButton = (page: Page) => page.locator('button[title="Preview"]')
+export const convertToLexButton = (page: Page) => page.locator('button[title="Convert to Lex"]')
+export const splitVerticalButton = (page: Page) => page.locator('button[title="Split vertically"]')
+export const splitHorizontalButton = (page: Page) =>
+  page.locator('button[title="Split horizontally"]')
+
+// -- Settings dialog --
+
+export const settingsHeading = (page: Page) => page.locator('h2:has-text("Settings")')
+export const saveChangesButton = (page: Page) => page.locator('text=Save Changes')
+
+// -- Status bar widgets --
+
+export const spellButton = (page: Page) => page.getByTestId('status-spell-button').first()
+export const spellMenu = (page: Page) => page.getByTestId('status-spell-menu').first()
+export const vimButton = (page: Page) => page.getByTestId('status-vim-button').first()
+
+// -- Panels --
+
+export const fileTree = (page: Page) => page.locator('[data-testid="file-tree"]')
+export const fileTreeItem = (page: Page, name: string | RegExp) =>
+  page.locator('[data-testid="file-tree-item"]', { hasText: name })
+export const outlineView = (page: Page) => page.locator('[data-testid="outline-view"]')
+export const editorPanes = (page: Page) => page.locator('[data-testid="editor-pane"]')
+export const editorTab = (page: Page, name: string | RegExp) =>
+  page.locator('[data-testid="editor-tab"]', { hasText: name })
+
+// -- Monaco internals (stable library selectors, centralized here) --
+
+export const suggestWidget = (page: Page) => page.locator('.suggest-widget')
+export const squigglyError = (page: Page) => page.locator('.squiggly-error')
+export const contextViewBlock = (page: Page) => page.locator('.context-view-block')
+export const monacoListRow = (page: Page) => page.locator('.monaco-list-row')
+
+// -- Toast --
+
+export const toast = (page: Page) => page.locator('[data-sonner-toast]')

--- a/tests/e2e/lib/wait.ts
+++ b/tests/e2e/lib/wait.ts
@@ -20,20 +20,16 @@ export async function waitForEditor(page: Page, timeout = 15000) {
 }
 
 /**
- * Wait until the active editor's model value satisfies a predicate.
+ * Wait until the active editor's model value contains the given substring.
  * Uses page.waitForFunction for Playwright's built-in retry/timeout.
  */
-export async function waitForEditorContent(
-  page: Page,
-  predicate: string,
-  { timeout = 10000 } = {}
-) {
+export async function waitForEditorContent(page: Page, text: string, { timeout = 10000 } = {}) {
   await page.waitForFunction(
-    (text) => {
+    (substring) => {
       const value = (window as any).lexTest?.getActiveEditorValue() ?? ''
-      return value.includes(text)
+      return value.includes(substring)
     },
-    predicate,
+    text,
     { timeout }
   )
 }

--- a/tests/e2e/lib/wait.ts
+++ b/tests/e2e/lib/wait.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/**
+ * Wait for the LSP client to complete initialization.
+ * Replaces all `waitForTimeout(2000) // Wait for LSP` calls.
+ */
+export async function waitForLsp(page: Page, timeout = 15000) {
+  await page.waitForFunction(() => Boolean((window as any).__lexLspReady), null, { timeout })
+}
+
+/**
+ * Wait for the Monaco editor to be visible AND the LSP to be ready.
+ * This is the most common setup sequence — replaces the
+ * `expect(editor).toBeVisible(); waitForTimeout(2000)` pair.
+ */
+export async function waitForEditor(page: Page, timeout = 15000) {
+  await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout })
+  await waitForLsp(page, timeout)
+}
+
+/**
+ * Wait until the active editor's model value satisfies a predicate.
+ * Uses page.waitForFunction for Playwright's built-in retry/timeout.
+ */
+export async function waitForEditorContent(
+  page: Page,
+  predicate: string,
+  { timeout = 10000 } = {}
+) {
+  await page.waitForFunction(
+    (text) => {
+      const value = (window as any).lexTest?.getActiveEditorValue() ?? ''
+      return value.includes(text)
+    },
+    predicate,
+    { timeout }
+  )
+}
+
+/**
+ * Wait for the spellcheck engine to be ready (dictionary loaded, service initialized).
+ */
+export async function waitForSpellcheck(page: Page, timeout = 20000) {
+  await page.waitForFunction(() => Boolean((window as any).lexTest?.isSpellcheckReady?.()), null, {
+    timeout,
+  })
+}


### PR DESCRIPTION
## Context

The E2E test suite has systemic issues making it slow and brittle:

- **30 arbitrary `waitForTimeout` calls** (mostly `waitForTimeout(2000) // Wait for LSP`) — the #1 source of both slowness and flakiness
- **No deterministic readiness signal** for the LSP client, forcing tests to guess timing
- **No shared helpers** — each test manually calls `launchApp()`/`electronApp.close()` with no guaranteed cleanup, duplicates locators and assertions
- **Shallow assertions** — checking DOM classes like `.squiggly-error` instead of querying the Monaco marker API
- **Fragile locators** — mix of `button[title="..."]`, `text=...`, and `h2:has-text(...)` scattered across files
- **Config gaps** — 30s timeout too tight for Electron+LSP, `retries: 0` means `trace: 'on-first-retry'` never fires
- **4 tests skipped** due to race conditions that proper readiness signals would fix
- **Not running in CI** (separate concern, tracked for a later PR)

This is **PR 1 of 3** in a planned overhaul:

1. **This PR** — Infrastructure: readiness signals, helper library, config
2. **PR 2** — Migration: rewrite all tests to use the new helpers, eliminate all `waitForTimeout`, fix/delete non-tests, migrate locators to `data-testid`
3. **PR 3** — CI enablement: add E2E job to GitHub Actions with trace artifacts

## Changes

### App code (3 files, +9 lines)

- **`src/lsp/client.ts`** — Set `window.__lexLspReady = true` when LSP initialization completes (right after the existing `lexed:lsp-ready` event dispatch). Clear on connection loss and dispose. The flag is pollable from tests; the event is not.
- **`src/hooks/useLexTestBridge.ts`** — Add `isLspReady()` to the `window.lexTest` bridge API
- **`src/vite-env.d.ts`** — Type declarations for `__lexLspReady` and previously-untyped bridge methods (`isSpellcheckReady`, `recheckSpelling`, `setCursor`)

### Test infrastructure (5 new files in `tests/e2e/lib/`)

| File | Purpose |
|------|---------|
| `app.ts` | Playwright fixture: `{ electronApp, page }` per test with guaranteed `close()` in teardown. Supports `test.use({ launchOptions })` |
| `wait.ts` | `waitForLsp`, `waitForEditor`, `waitForEditorContent`, `waitForSpellcheck` — deterministic replacements for `waitForTimeout` |
| `locators.ts` | Centralized locator factories (editor, toolbar buttons, panels, Monaco internals) — one file to update instead of every test |
| `assertions.ts` | `expectMarkers` (deep match on Monaco marker API), `expectFormattingRequest`, `expectEditorValue`, `expectToast` |
| `index.ts` | Barrel export |

### Config

- **`playwright.config.ts`** — Timeout 30s→60s, retries 0→1 (enables trace collection)
- **`tests/e2e/helpers.ts`** — Export `AppLaunchOptions` type for the fixture

### What this PR does NOT change

Existing tests are untouched — the helpers are purely additive. All 22 previously-passing tests still pass; the same 3 spellcheck tests that fail due to pre-existing state isolation issues still fail identically; the same 4 tests remain skipped.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (only pre-existing `generate-icons.mjs` error)
- [x] Full E2E suite: 22 passed, 3 failed (pre-existing spellcheck isolation), 4 skipped — identical to clean main
- [x] Spellcheck tests pass when run individually (confirming failures are ordering/isolation, not regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)