### PR TITLE
Add E2E tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,50 @@ jobs:
       - name: Unit tests
         run: npm run test:unit -- --run
 
-      # Note: E2E tests require display and lex-lsp binary
-      # These are run locally via pre-commit hook
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared module
+        run: |
+          cd shared
+          npm ci
+          npm run build
+
+      - name: Download lex-lsp binary
+        run: bash scripts/download-lex-lsp.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build renderer and main process
+        run: npm run icons && npx tsc && npx vite build
+
+      - name: Run E2E tests
+        run: xvfb-run --auto-servernum npx playwright test tests/e2e
+        env:
+          LEX_E2E_USE_BUILD: '1'
+          LEX_SKIP_E2E_BUILD: '1'
+          LEX_HIDE_WINDOW: '1'
+          LEX_DISABLE_PERSISTENCE: '1'
+          PLAYWRIGHT_BROWSERS_PATH: '0'
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: '0'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,7 +79,6 @@ jobs:
           LEX_SKIP_E2E_BUILD: '1'
           LEX_HIDE_WINDOW: '1'
           LEX_DISABLE_PERSISTENCE: '1'
-          PLAYWRIGHT_BROWSERS_PATH: '0'
 
       - name: Upload traces on failure
         if: failure()

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -8,7 +8,11 @@ export type AppLaunchOptions = {
 }
 
 export async function launchApp(options: AppLaunchOptions = {}) {
-  const { extraArgs = [], env: envOverrides = {} } = options
+  const { extraArgs: userArgs = [], env: envOverrides = {} } = options
+
+  // Electron's SUID sandbox doesn't work in CI containers; disable it on Linux CI
+  const ciArgs = process.platform === 'linux' && process.env.CI ? ['--no-sandbox'] : []
+  const extraArgs = [...ciArgs, ...userArgs]
   const useBuiltRenderer = process.env.LEX_E2E_USE_BUILD === '1'
   const devServerUrl =
     process.env.VITE_DEV_SERVER_URL || (useBuiltRenderer ? undefined : 'http://localhost:5173')


### PR DESCRIPTION
## Context

This is **PR 3 of 3** in the E2E test overhaul (follows #8 infrastructure, #9 migration).

E2E tests were previously only run locally via the pre-commit hook. This PR adds them to CI so regressions are caught on every push.

## Changes

Adds a new `e2e` job to the CI workflow that runs in parallel with the existing `build` (typecheck/lint/unit) job:

1. **Checkout + install** — same as the build job (submodules, Node 20, npm ci, shared module)
2. **Download lex-lsp** — fetches the binary from GitHub releases via `scripts/download-lex-lsp.sh`
3. **Build renderer** — `npm run icons && npx tsc && npx vite build` (skips `electron-builder` packaging which isn't needed for tests)
4. **Run E2E tests** — `xvfb-run --auto-servernum npx playwright test` with:
   - `LEX_E2E_USE_BUILD=1` — tests load from built files, not a dev server
   - `LEX_SKIP_E2E_BUILD=1` — skip global-setup rebuild (already built)
   - `LEX_HIDE_WINDOW=1` — headless Electron
   - `LEX_DISABLE_PERSISTENCE=1` — clean state per test
5. **Upload traces** — on failure, uploads `test-results/` as an artifact (7-day retention) with Playwright traces for debugging

Runs on all pushes to all branches + PRs to main.

## Test plan

- [x] Workflow syntax is valid YAML
- [x] `lex-lsp` download uses `GITHUB_TOKEN` for authenticated access to release assets
- [x] `build-quicklook.sh` skips on non-Darwin (line 4: `if [[ "$(uname -s)" != "Darwin" ]]`)
- [x] `packaged.spec.ts` auto-skips when `LEX_SKIP_E2E_BUILD=1` is set
- [ ] CI run passes (will verify once pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)