### PR TITLE
Fix spellcheck add-to-dictionary crashing the editor

### DIFF
--- a/electron/lsp-manager.ts
+++ b/electron/lsp-manager.ts
@@ -76,6 +76,22 @@ export class LspManager {
 
   setWebContents(webContents: WebContents) {
     this.webContents = webContents
+    let initialLoadComplete = false
+
+    webContents.on('did-finish-load', () => {
+      initialLoadComplete = true
+    })
+
+    // Restart LSP on page reload (e.g. Vite HMR) so the new renderer
+    // can send a fresh initialize request to a clean LSP process.
+    webContents.on('did-start-navigation', () => {
+      if (initialLoadComplete && this.lspProcess) {
+        log('Renderer navigating — restarting LSP process')
+        this.stop()
+        this.start(this.rootPath ?? undefined)
+      }
+    })
+
     // Clear reference when webContents is destroyed to prevent errors
     webContents.on('destroyed', () => {
       this.webContents = null

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -856,6 +856,10 @@ function getDictionariesPath(): string {
 }
 
 function getCustomDictionaryPath(): string {
+  if (app.isPackaged) {
+    // In production the app bundle is read-only; store custom words in user data
+    return path.join(app.getPath('userData'), 'custom.dic')
+  }
   return path.join(getDictionariesPath(), 'custom.dic')
 }
 

--- a/tests/e2e/spellcheck.spec.ts
+++ b/tests/e2e/spellcheck.spec.ts
@@ -95,11 +95,7 @@ test.describe('Spellcheck', () => {
       .toMatchObject({ enabled: true, language: 'fr_FR' })
   })
 
-  // Fixme: LSP binary intermittently rejects initialize requests with -32600 (Invalid request)
-  // on the third Electron instance in a test run, causing this test to time out waiting for
-  // __lexLspReady. Reproduces identically on clean main. Root cause is in the lex-lsp binary,
-  // not the test.
-  test.fixme('successfully adds words to dictionary', async ({ page }) => {
+  test('successfully adds words to dictionary', async ({ page }) => {
     test.setTimeout(60000)
 
     // 0. Reset custom dictionary and enable spellcheck

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,22 +22,23 @@ export default defineConfig({
       // Ployfill the Electron and Node.js API for Renderer process.
       // If you want use Node.js in Renderer process, the `nodeIntegration` needs to be enabled in the Main process.
       // See 👉 https://github.com/electron-vite/vite-plugin-electron-renderer
-      renderer: process.env.NODE_ENV === 'test'
-        // https://github.com/electron-vite/vite-plugin-electron-renderer/issues/78#issuecomment-2053600808
-        ? undefined
-        : {},
+      renderer:
+        process.env.NODE_ENV === 'test'
+          ? // https://github.com/electron-vite/vite-plugin-electron-renderer/issues/78#issuecomment-2053600808
+            undefined
+          : {},
     }),
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@lex/shared": path.resolve(__dirname, "./shared/src/index.ts"),
+      '@': path.resolve(__dirname, './src'),
+      '@lex/shared': path.resolve(__dirname, './shared/src/index.ts'),
     },
   },
   server: {
     watch: {
-      // Ignore .lex files and welcome directory - these are user documents, not source code
-      ignored: ['**/*.lex', '**/welcome/**'],
+      // Ignore user documents and dictionaries - not source code
+      ignored: ['**/*.lex', '**/welcome/**', '**/dictionaries/**'],
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- **Vite watch fix**: `dictionaries/custom.dic` was not in the Vite ignore list — writing a word to the custom dictionary triggered a full page reload, destroying the renderer and LSP connection mid-operation.
- **LSP restart on navigation**: After any page reload the LSP process stayed alive but already-initialized, so the new renderer's `initialize` request was rejected (`-32600 Invalid Request`). `LspManager` now restarts the LSP process when the renderer navigates, so each load gets a fresh server — respecting the LSP protocol's one-shot initialize semantics.
- **Production dictionary path**: In packaged builds, `custom.dic` was written inside the read-only app bundle (`process.resourcesPath`). Moved to `app.getPath('userData')` for production.
- **Re-enabled E2E test**: The "add to dictionary" test was `test.fixme` due to this exact bug. Now passes.

## Test plan

- [x] Unit tests pass (28/28)
- [x] E2E spellcheck suite passes (3/3, including the previously-skipped add-to-dictionary test)
- [x] Full pre-commit hook passes (lint, typecheck, build, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)