### PR TITLE
Send workspace/didChangeWorkspaceFolders on root change

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lex-lsp": {
-      "version": "v0.4.0",
+      "version": "v0.7.4",
       "repo": "lex-fmt/lex"
     }
   }

--- a/src/hooks/useRootFolder.ts
+++ b/src/hooks/useRootFolder.ts
@@ -1,41 +1,54 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react'
+import { notifyWorkspaceFoldersChanged } from '@/lsp/init'
 
 export function useRootFolder() {
-  const [rootPath, setRootPath] = useState<string | undefined>(undefined);
+  const [rootPath, setRootPath] = useState<string | undefined>(undefined)
+  const prevRootRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    let mounted = true;
+    let mounted = true
     const loadInitialFolder = async () => {
       try {
-        const folder = await window.ipcRenderer.getInitialFolder();
+        const folder = await window.ipcRenderer.getInitialFolder()
         if (mounted && folder) {
-          setRootPath(folder);
+          setRootPath(folder)
         }
       } catch (error) {
-        console.error('useRootFolder: failed to load initial folder', error);
+        console.error('useRootFolder: failed to load initial folder', error)
       }
-    };
-    loadInitialFolder();
+    }
+    loadInitialFolder()
     return () => {
-      mounted = false;
-    };
-  }, []);
+      mounted = false
+    }
+  }, [])
 
   useEffect(() => {
     if (rootPath) {
-      const folderName = rootPath.split('/').pop() || rootPath;
-      document.title = `LexEd - ${folderName}`;
+      const folderName = rootPath.split('/').pop() || rootPath
+      document.title = `LexEd - ${folderName}`
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__lexWorkspaceRoot = rootPath;
+      ;(window as any).__lexWorkspaceRoot = rootPath
     } else {
-      document.title = 'LexEd';
+      document.title = 'LexEd'
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if ((window as any).__lexWorkspaceRoot) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        delete (window as any).__lexWorkspaceRoot;
+        delete (window as any).__lexWorkspaceRoot
       }
     }
-  }, [rootPath]);
 
-  return { rootPath, setRootPath };
+    // Notify LSP when workspace root changes
+    const prev = prevRootRef.current
+    if (rootPath !== prev) {
+      const removed = prev ? [prev] : []
+      const added = rootPath ? [rootPath] : []
+      if (added.length > 0 || removed.length > 0) {
+        notifyWorkspaceFoldersChanged(added, removed)
+      }
+      prevRootRef.current = rootPath
+    }
+  }, [rootPath])
+
+  return { rootPath, setRootPath }
 }

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -5,6 +5,7 @@ import {
   InitializeParams,
   InitializeRequest,
   InitializedNotification,
+  DidChangeWorkspaceFoldersNotification,
   MessageReader,
   MessageWriter,
 } from 'vscode-languageserver-protocol/browser'
@@ -260,6 +261,7 @@ export class LspClient {
             workspaceEdit: {
               documentChanges: true,
             },
+            workspaceFolders: true,
             didChangeConfiguration: { dynamicRegistration: true },
             didChangeWatchedFiles: { dynamicRegistration: true },
             symbol: { dynamicRegistration: true },
@@ -461,6 +463,27 @@ export class LspClient {
       return
     }
     this.connection.sendNotification(method, params)
+  }
+
+  public async notifyWorkspaceFoldersChanged(added: string[], removed: string[]): Promise<void> {
+    if (!this.readyPromise) return
+    await this.readyPromise
+    if (!this.connection) return
+
+    const toFolder = (p: string) => ({
+      uri: monaco.Uri.file(p).toString(),
+      name: p.split('/').pop() || p,
+    })
+
+    this.connection.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
+      event: {
+        added: added.map(toFolder),
+        removed: removed.map(toFolder),
+      },
+    })
+    log.debug(
+      `[LspClient] Sent workspace/didChangeWorkspaceFolders (added=${added}, removed=${removed})`
+    )
   }
 }
 

--- a/src/lsp/init.ts
+++ b/src/lsp/init.ts
@@ -29,3 +29,10 @@ export function ensureLspInitialized(rootPath?: string) {
 export function hasCustomTransport(): boolean {
   return transportFactorySet
 }
+
+/**
+ * Notify the LSP server that workspace folders changed.
+ */
+export function notifyWorkspaceFoldersChanged(added: string[], removed: string[]) {
+  lspClient.notifyWorkspaceFoldersChanged(added, removed)
+}

--- a/tests/e2e/split-panes.spec.ts
+++ b/tests/e2e/split-panes.spec.ts
@@ -22,9 +22,7 @@ test.describe('Split Panes', () => {
     }
   })
 
-  // Skipped: race condition between settings loading (lastFolder) and LSP initialization
-  // causing rootUri to be null in test environment, leading to LSP crashing.
-  // Visual verification confirms functionality works.
+  // TODO: re-enable once launchApp test infrastructure handles workspace init race condition
   test.skip('opens files per pane and syncs outline and explorer', async () => {
     test.setTimeout(60000)
     const electronApp = await launchApp()


### PR DESCRIPTION
## Summary
- Add `notifyWorkspaceFoldersChanged` to LSP client and send `workspace/didChangeWorkspaceFolders` when the workspace root changes at runtime
- Advertise `workspaceFolders: true` in client capabilities during LSP initialization
- Bump lex-lsp dependency to v0.7.4 (lex-fmt/lex#449) which adds server-side support
- Update skip comment on split-panes E2E test

Depends on lex-fmt/lex#449 (merged, released as v0.7.4).

## Test plan
- [x] All 28 unit tests pass
- [x] TypeScript type check passes
- [x] 20/22 E2E tests pass (2 format tests fail identically on main — pre-existing)
- [x] lex-lsp v0.7.4 successfully downloaded and bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)