### PR TITLE
Rename LSP binary references: lex-lsp -> lexd-lsp

### DIFF
--- a/.claude/skills/lexed-development/SKILL.md
+++ b/.claude/skills/lexed-development/SKILL.md
@@ -54,7 +54,7 @@ npm run format       # Prettier
    - `npm run build:quicklook` - Build QuickLook extension (macOS only)
 
 2. `npm run build` executes:
-   - `scripts/fetch-deps.sh` - Download lex-lsp binary from GitHub releases
+   - `scripts/fetch-deps.sh` - Download lexd-lsp binary from GitHub releases
    - `tsc` - TypeScript compilation
    - `vite build` - Bundle renderer, main, and preload
    - `electron-builder` - Package into DMG/installer
@@ -63,15 +63,15 @@ npm run format       # Prettier
 
 ### Binary Resolution (in order)
 1. `LEX_LSP_PATH` environment variable (for local dev)
-2. Bundled binary in `resources/lex-lsp` (production)
+2. Bundled binary in `resources/lexd-lsp` (production)
 
 ### Development with Local LSP
 ```bash
-# Build lex-lsp from the lex repo
-cd /path/to/lex && cargo build -p lex-lsp
+# Build lexd-lsp from the lex repo
+cd /path/to/lex && cargo build -p lexd-lsp
 
 # Run lexed with local LSP
-LEX_LSP_PATH=/path/to/lex/target/debug/lex-lsp npm run dev:local
+LEX_LSP_PATH=/path/to/lex/target/debug/lexd-lsp npm run dev:local
 ```
 
 ## Testing

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
-# Local development: use a locally-built lex-lsp with `npm run dev:local`
+# Local development: use a locally-built lexd-lsp with `npm run dev:local`
 #
 # `npm run dev` downloads the pinned release binary automatically.
 # `npm run dev:local` uses LEX_LSP_PATH for a local build — set it here:
 #
-# export LEX_LSP_PATH="${PWD}/../lex/target/debug/lex-lsp"
+# export LEX_LSP_PATH="${PWD}/../lex/target/debug/lexd-lsp"

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ node_modules
 /tmp
 
 # Downloaded binaries
-/resources/lex-lsp
-/resources/lex-lsp.exe
+/resources/lexd-lsp
+/resources/lexd-lsp.exe
 
 # Logs
 logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Breaking
+
+- LSP binary renamed from `lex-lsp` to `lexd-lsp` (matches lex-fmt/lex#450)
+- Release artifact names change: `lexd-lsp-{target}.tar.gz`
+- `shared/lex-deps.json` key changed from `lex-lsp` to `lexd-lsp`
+
+Updates all references to the renamed binary: electron-builder config, fetch-deps.sh, lsp-manager, QuickLook extension, e2e helpers, and documentation.

--- a/README.lex
+++ b/README.lex
@@ -22,13 +22,13 @@ Lex LexEd Architecture
 
         Manages application lifecycle, native file system access, and window management.
 
-        Spawns and manages the `lex-lsp` binary as a child process.
+        Spawns and manages the `lexd-lsp` binary as a child process.
 
         Acts as a bridge between the Renderer and the LSP, forwarding JSON-RPC messages.
 
     3. Language Server (Rust)
 
-        The `lex-lsp` binary, written in Rust.
+        The `lexd-lsp` binary, written in Rust.
 
         Provides language intelligence: diagnostics, document symbols (outline), hover information, and semantic tokens.
 
@@ -74,7 +74,7 @@ Lex LexEd Architecture
 
         The LSP client supports pluggable transport backends via `setLspTransportFactory()`. This allows:
 
-        - Electron: IPC-based transport to communicate with spawned `lex-lsp` process
+        - Electron: IPC-based transport to communicate with spawned `lexd-lsp` process
         - Web: WASM-based transport using `lex-wasm` compiled language server
 
         The transport factory is set at application startup before LSP initialization, ensuring all language features use the correct communication mechanism.
@@ -89,15 +89,15 @@ Lex LexEd Architecture
 
     2. Main to LSP
 
-        The Main process listens on `lsp-input`, prepends the required `Content-Length` header, and writes the data to the `lex-lsp` process's standard input (stdin).
+        The Main process listens on `lsp-input`, prepends the required `Content-Length` header, and writes the data to the `lexd-lsp` process's standard input (stdin).
 
     3. LSP Processing
 
-        The `lex-lsp` binary reads from stdin, parses the message, processes the request (e.g., parsing the Lex document, generating tokens), and writes the response to standard output (stdout).
+        The `lexd-lsp` binary reads from stdin, parses the message, processes the request (e.g., parsing the Lex document, generating tokens), and writes the response to standard output (stdout).
 
     4. LSP to Main
 
-        The Main process captures the `lex-lsp` stdout stream.
+        The Main process captures the `lexd-lsp` stdout stream.
 
     5. Main to Renderer
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Standalone desktop editor for [Lex](https://github.com/lex-fmt/lex) — a plain 
 
 ## Overview
 
-LexEd is an Electron app built with React, TypeScript, and Monaco editor. All language features come from `lex-lsp` via LSP — no editor-side language logic.
+LexEd is an Electron app built with React, TypeScript, and Monaco editor. All language features come from `lexd-lsp` via LSP — no editor-side language logic.
 
 - Monochrome theme (typography and grayscale, adapts to light/dark)
 - Multi-pane editing with split views

--- a/electron/lsp-manager.ts
+++ b/electron/lsp-manager.ts
@@ -112,7 +112,7 @@ export class LspManager {
 
     this.rootPath = rootPath || null
 
-    const binaryName = process.platform === 'win32' ? 'lex-lsp.exe' : 'lex-lsp'
+    const binaryName = process.platform === 'win32' ? 'lexd-lsp.exe' : 'lexd-lsp'
     let lspPath: string
     let warning: string | undefined
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "icons": "node ./scripts/generate-icons.mjs",
     "prebuild": "npm run icons && npm run build:quicklook",
     "build:quicklook": "bash ./scripts/build-quicklook.sh",
-    "build": "bash scripts/fetch-deps.sh && tsc && vite build && electron-builder",
+    "build": "bash scripts/fetch-deps.sh --if-missing && tsc && vite build && electron-builder",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0",
@@ -111,8 +111,8 @@
       ],
       "extraResources": [
         {
-          "from": "resources/lex-lsp",
-          "to": "lex-lsp"
+          "from": "resources/lexd-lsp",
+          "to": "lexd-lsp"
         },
         {
           "from": "bin",
@@ -165,8 +165,8 @@
       ],
       "extraResources": [
         {
-          "from": "resources/lex-lsp.exe",
-          "to": "lex-lsp.exe"
+          "from": "resources/lexd-lsp.exe",
+          "to": "lexd-lsp.exe"
         }
       ]
     },
@@ -178,8 +178,8 @@
       "category": "Utility",
       "extraResources": [
         {
-          "from": "resources/lex-lsp",
-          "to": "lex-lsp"
+          "from": "resources/lexd-lsp",
+          "to": "lexd-lsp"
         }
       ]
     },

--- a/quicklook/LexQuickLook/PreviewProvider.swift
+++ b/quicklook/LexQuickLook/PreviewProvider.swift
@@ -7,10 +7,10 @@ class PreviewProvider: QLPreviewProvider {
     func providePreview(for request: QLFilePreviewRequest) async throws -> QLPreviewReply {
         let fileURL = request.fileURL
 
-        // Find lex-cli binary - check app bundle first, then PATH
+        // Find lexd-lsp binary - check app bundle first, then PATH
         let lexCLI = findLexCLI()
 
-        // Generate PNG preview using lex-cli
+        // Generate PNG preview using lexd-lsp
         let pngData = try await generatePreview(for: fileURL, using: lexCLI)
 
         // Return the PNG as the preview
@@ -22,11 +22,11 @@ class PreviewProvider: QLPreviewProvider {
 
     private func findLexCLI() -> URL {
         // Extension is at: LexEd.app/Contents/PlugIns/LexQuickLook.appex/Contents/MacOS/LexQuickLook
-        // We need:         LexEd.app/Contents/Resources/lex-lsp
+        // We need:         LexEd.app/Contents/Resources/lexd-lsp
         // So from extension bundle, go up to Contents, then into Resources
         if let extensionBundle = Bundle.main.bundleURL.deletingLastPathComponent() // PlugIns/
             .deletingLastPathComponent() // Contents/
-            .appendingPathComponent("Resources/lex-lsp") as URL? {
+            .appendingPathComponent("Resources/lexd-lsp") as URL? {
             if FileManager.default.fileExists(atPath: extensionBundle.path) {
                 return extensionBundle
             }
@@ -34,10 +34,10 @@ class PreviewProvider: QLPreviewProvider {
 
         // Fallback to common installation paths
         let candidates = [
-            "/Applications/LexEd.app/Contents/Resources/lex-lsp",
-            "/usr/local/bin/lex",
-            "/opt/homebrew/bin/lex",
-            NSHomeDirectory() + "/.cargo/bin/lex"
+            "/Applications/LexEd.app/Contents/Resources/lexd-lsp",
+            "/usr/local/bin/lexd",
+            "/opt/homebrew/bin/lexd",
+            NSHomeDirectory() + "/.cargo/bin/lexd"
         ]
 
         for candidate in candidates {
@@ -47,7 +47,7 @@ class PreviewProvider: QLPreviewProvider {
         }
 
         // Default
-        return URL(fileURLWithPath: "/Applications/LexEd.app/Contents/Resources/lex-lsp")
+        return URL(fileURLWithPath: "/Applications/LexEd.app/Contents/Resources/lexd-lsp")
     }
 
     private func generatePreview(for fileURL: URL, using lexCLI: URL) async throws -> Data {

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -110,7 +110,7 @@ build_dep() {
   local dep="$1" target="$2"
 
   case "$dep" in
-    lex-lsp)
+    lexd-lsp)
       local repo_root
       repo_root="$(cd "$APP_DIR/.." && pwd)/lex"
       if [[ ! -d "$repo_root" ]]; then
@@ -119,28 +119,28 @@ build_dep() {
         exit 1
       fi
       if ! command -v cargo >/dev/null 2>&1; then
-        echo "cargo is required to build lex-lsp from source" >&2
+        echo "cargo is required to build lexd-lsp from source" >&2
         exit 1
       fi
       pushd "$repo_root" >/dev/null
       if [[ -n "$target" ]]; then
-        cargo build --bin lex-lsp --release --target "$target"
-        local bin_src="$repo_root/target/$target/release/lex-lsp"
+        cargo build --bin lexd-lsp --release --target "$target"
+        local bin_src="$repo_root/target/$target/release/lexd-lsp"
       else
-        cargo build --bin lex-lsp --release
-        local bin_src="$repo_root/target/release/lex-lsp"
+        cargo build --bin lexd-lsp --release
+        local bin_src="$repo_root/target/release/lexd-lsp"
       fi
       popd >/dev/null
       [[ ! -f "$bin_src" && -f "${bin_src}.exe" ]] && bin_src="${bin_src}.exe"
       if [[ ! -f "$bin_src" ]]; then
-        echo "lex-lsp binary not found at $bin_src" >&2
+        echo "lexd-lsp binary not found at $bin_src" >&2
         exit 1
       fi
-      local dest="$RESOURCES_DIR/lex-lsp"
+      local dest="$RESOURCES_DIR/lexd-lsp"
       [[ "$bin_src" == *.exe ]] && dest="${dest}.exe"
       cp "$bin_src" "$dest"
       chmod +x "$dest"
-      echo "lex-lsp (from source) → $dest"
+      echo "lexd-lsp (from source) → $dest"
       ;;
     *)
       echo "Don't know how to build $dep from source" >&2

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.7.4",
+      "version": "v0.8.0",
       "repo": "lex-fmt/lex"
     }
   }

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,6 +1,6 @@
 {
   "deps": {
-    "lex-lsp": {
+    "lexd-lsp": {
       "version": "v0.7.4",
       "repo": "lex-fmt/lex"
     }

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,8 +1,8 @@
 import lexDeps from '../lex-deps.json' with { type: 'json' };
 
-// Pinned lex-lsp version - binaries downloaded from GitHub releases
-export const LEX_LSP_VERSION = lexDeps.deps['lex-lsp'].version;
-export const LEX_LSP_REPO = lexDeps.deps['lex-lsp'].repo;
+// Pinned lexd-lsp version - binaries downloaded from GitHub releases
+export const LEX_LSP_VERSION = lexDeps.deps['lexd-lsp'].version;
+export const LEX_LSP_REPO = lexDeps.deps['lexd-lsp'].repo;
 
 export const TOKEN_TYPES = [
     "DocumentTitle",

--- a/shared/src/platform.ts
+++ b/shared/src/platform.ts
@@ -272,7 +272,7 @@ export interface SettingsAdapter {
  * LSP transport factory.
  *
  * Creates the message reader/writer pair for LSP communication:
- * - Electron: IPC-based transport to spawned lex-lsp binary
+ * - Electron: IPC-based transport to spawned lexd-lsp binary
  * - Web: Direct calls to lex-wasm module
  */
 export interface LspTransport {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,7 +141,7 @@ function AppContent() {
               status.message ??
               `Lex LSP binary was not found${status.path ? ` at ${status.path}` : ''}.`,
             suggestion:
-              'Run "bash scripts/fetch-deps.sh" to download lex-lsp, or use "npm run dev" which fetches it automatically.',
+              'Run "bash scripts/fetch-deps.sh" to download lexd-lsp, or use "npm run dev" which fetches it automatically.',
           })
         } else if (status.status === 'error') {
           setLspError({
@@ -153,7 +153,7 @@ function AppContent() {
           setLspError({
             title: 'Lex Language Server Stopped',
             message: 'The language server exited unexpectedly.',
-            suggestion: 'Restart LexEd or rebuild lex-lsp to continue.',
+            suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.',
           })
         }
       }) ?? (() => {})
@@ -164,7 +164,7 @@ function AppContent() {
       setLspError({
         title: 'Lex Language Server Unavailable',
         message: detail?.message ?? 'The language server is not responding.',
-        suggestion: 'Restart LexEd or rebuild lex-lsp to continue.',
+        suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.',
       })
     }
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -35,7 +35,7 @@ export async function launchApp(options: AppLaunchOptions = {}) {
   }
 
   if (useBuiltRenderer) {
-    const binaryName = process.platform === 'win32' ? 'lex-lsp.exe' : 'lex-lsp'
+    const binaryName = process.platform === 'win32' ? 'lexd-lsp.exe' : 'lexd-lsp'
     env.LEX_LSP_PATH = path.join(process.cwd(), 'resources', binaryName)
   }
 

--- a/verify_lsp.py
+++ b/verify_lsp.py
@@ -35,8 +35,8 @@ def read_response(proc):
 
 def main():
     # Path to the built LSP binary
-    # It should be in target/debug/lex-lsp since we built it via npm run build -> cargo build
-    lsp_path = "../../target/debug/lex-lsp"
+    # It should be in target/debug/lexd-lsp since we built it via npm run build -> cargo build
+    lsp_path = "../../target/debug/lexd-lsp"
     
     print(f"Starting LSP from {lsp_path}")
     proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

- Rename all `lex-lsp` binary references to `lexd-lsp` (companion to lex-fmt/lex#450)
- Update `lex-deps.json`, electron-builder config, fetch-deps.sh, lsp-manager, QuickLook, e2e helpers, and docs
- Build script now uses `--if-missing` to avoid re-downloading when binary is present

## Test plan

- [x] `npm run typecheck` passes
- [x] `bash scripts/fetch-deps.sh --from-source` builds and places `resources/lexd-lsp`
- [x] Full build passes (pre-commit hook: lint, typecheck, build, unit tests, e2e tests)
- [ ] Verify `npm run dev` launches with locally-built `lexd-lsp`

**Depends on**: lex-fmt/lex#450 being merged and released before this PR's `fetch-deps.sh` can download from GitHub releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)