### PR TITLE
e2e: capture runtime errors during every Playwright test

### DIFF
--- a/tests/e2e/lib/app.ts
+++ b/tests/e2e/lib/app.ts
@@ -26,7 +26,10 @@ export type AppFixtures = {
   electronApp: ElectronApplication
   page: Page
   appLaunchOptions: AppLaunchOptions
-  runtimeErrors: CapturedRuntimeError[]
+  // `readonly` so test code can't accidentally clear or mutate the
+  // collector and mask runtime errors before the teardown assertion
+  // runs.
+  runtimeErrors: ReadonlyArray<CapturedRuntimeError>
 }
 
 const defaultAppLaunchOptions: AppLaunchOptions = {
@@ -130,10 +133,14 @@ export const test = base.extend<AppFixtures>({
         throw useError
       }
 
-      // Only auto-fail on errors when the test itself passed. Read
-      // the latest status from the testInfo — by this point the test
-      // body has completed and Playwright has finalised it.
-      if (testInfo.status === testInfo.expectedStatus && errors.length > 0) {
+      // Only auto-fail on errors when the test actually passed.
+      // `status === expectedStatus` would also be true for a test
+      // marked as expected-to-fail (both fields land on `'failed'`),
+      // and asserting in that case would convert an expected failure
+      // into an unexpected teardown failure with a different message.
+      // Use the literal 'passed' check so we only attribute runtime
+      // errors to a clean test run.
+      if (testInfo.status === 'passed' && errors.length > 0) {
         const lines = errors.map((e, i) => `  [${i + 1}] (${e.source}) ${e.message}`)
         throw new Error(
           `Runtime errors captured during test (${errors.length}):\n${lines.join('\n')}`

--- a/tests/e2e/lib/app.ts
+++ b/tests/e2e/lib/app.ts
@@ -13,14 +13,55 @@ import { launchApp, type AppLaunchOptions } from '../helpers'
  * To customize launch options for a describe block:
  *   test.use({ appLaunchOptions: { env: { LEX_DISABLE_PERSISTENCE: '0' } } })
  */
+
+/** A runtime error observed in the renderer during a test. */
+export interface CapturedRuntimeError {
+  /** Where the error came from: a Playwright `pageerror` or a `console.error`. */
+  source: 'pageerror' | 'console'
+  /** The error message text. */
+  message: string
+}
+
 export type AppFixtures = {
   electronApp: ElectronApplication
   page: Page
   appLaunchOptions: AppLaunchOptions
+  runtimeErrors: CapturedRuntimeError[]
 }
 
 const defaultAppLaunchOptions: AppLaunchOptions = {
   env: { LEX_DISABLE_PERSISTENCE: '1' },
+}
+
+/**
+ * Messages we know are emitted during normal app startup and are not
+ * produced by our own code — matching against substrings. Add sparingly;
+ * the goal is to keep the error capture meaningful, not permissive.
+ */
+const IGNORED_ERROR_PATTERNS: ReadonlyArray<string> = [
+  // Chromium/Electron DevTools noise in headless mode.
+  'Autofill.enable',
+  'Autofill.setAddresses',
+  // React DevTools banner when the extension isn't installed.
+  'Download the React DevTools',
+  // TODO: lex-fmt/lex — `lex-lsp` occasionally emits a semantic token
+  //   whose `end` column exceeds the line's length, which Monaco
+  //   complains about on certain fixtures (observed with
+  //   `preview.spec.ts` → `general.lex`). Ignored here so this
+  //   harness PR isn't blocked; track as its own bug with a
+  //   minimum-repro document.
+  'Invalid Semantic Tokens Data From Extension',
+  // TODO: lexed — `LEX_E2E_USE_BUILD=1` (production bundle) path
+  //   logs `net::ERR_FILE_NOT_FOUND` in the renderer on startup,
+  //   suggesting something in the built index.html references an
+  //   asset that doesn't ship. Pre-existing; allowlisted so the
+  //   harness lands. Track as its own bug once we've narrowed the
+  //   missing resource.
+  'Failed to load resource: net::ERR_FILE_NOT_FOUND',
+]
+
+function shouldIgnore(message: string): boolean {
+  return IGNORED_ERROR_PATTERNS.some((pattern) => message.includes(pattern))
 }
 
 export const test = base.extend<AppFixtures>({
@@ -43,6 +84,64 @@ export const test = base.extend<AppFixtures>({
 
     await use(page)
   },
+  // Per-test collector for runtime errors. Pageerrors (uncaught
+  // exceptions, unhandled rejections) and `console.error` calls both
+  // land here, minus anything matched by the allowlist above.
+  //
+  // Marked `auto: true` so listeners are installed on every test's
+  // page whether or not the test body references `runtimeErrors`.
+  // Tests that want to inspect the array mid-run can still accept it
+  // as a parameter and/or call `assertNoRuntimeErrors` from
+  // `./assertions`; tests that don't accept it still benefit from the
+  // teardown-time auto-assertion below, which fails any passing test
+  // that silently captured runtime errors.
+  runtimeErrors: [
+    async ({ page }, use, testInfo) => {
+      const errors: CapturedRuntimeError[] = []
+
+      const onPageError = (err: Error) => {
+        if (shouldIgnore(err.message)) return
+        errors.push({ source: 'pageerror', message: err.message })
+      }
+      const onConsole = (msg: { type(): string; text(): string }) => {
+        if (msg.type() !== 'error') return
+        const text = msg.text()
+        if (shouldIgnore(text)) return
+        errors.push({ source: 'console', message: text })
+      }
+
+      page.on('pageerror', onPageError)
+      page.on('console', onConsole)
+
+      let useError: unknown
+      try {
+        await use(errors)
+      } catch (err) {
+        useError = err
+      }
+
+      page.off('pageerror', onPageError)
+      page.off('console', onConsole)
+
+      if (useError !== undefined) {
+        // The test body already failed; surface that as-is so the
+        // reported failure points at the real cause rather than a
+        // teardown-time assertion.
+        throw useError
+      }
+
+      // Only auto-fail on errors when the test itself passed. Read
+      // the latest status from the testInfo — by this point the test
+      // body has completed and Playwright has finalised it.
+      if (testInfo.status === testInfo.expectedStatus && errors.length > 0) {
+        const lines = errors.map((e, i) => `  [${i + 1}] (${e.source}) ${e.message}`)
+        throw new Error(
+          `Runtime errors captured during test (${errors.length}):\n${lines.join('\n')}`
+        )
+      }
+    },
+    { auto: true },
+  ],
 })
 
 export { expect } from '@playwright/test'

--- a/tests/e2e/lib/assertions.ts
+++ b/tests/e2e/lib/assertions.ts
@@ -147,3 +147,20 @@ export async function expectToast(page: Page, text: string | RegExp, timeout = 1
     await expect(toastLocator).toContainText(text)
   }
 }
+
+/**
+ * Assert that no renderer-side runtime errors have been captured so far
+ * in this test. Callable mid-test after an action that should be
+ * error-free; the fixture also auto-asserts on teardown so missing this
+ * call doesn't hide errors.
+ */
+export function assertNoRuntimeErrors(
+  errors: ReadonlyArray<{ source: string; message: string }>,
+  context?: string
+) {
+  if (errors.length === 0) return
+  const lines = errors.map((e, i) => `  [${i + 1}] (${e.source}) ${e.message}`)
+  throw new Error(
+    `${context ? context + ': ' : ''}runtime errors captured (${errors.length}):\n${lines.join('\n')}`
+  )
+}

--- a/tests/e2e/lib/index.ts
+++ b/tests/e2e/lib/index.ts
@@ -14,6 +14,7 @@ export {
   expectFormattingRequest,
   expectEditorValue,
   expectToast,
+  assertNoRuntimeErrors,
 } from './assertions'
 export {
   focusEditor,

--- a/tests/e2e/no-errors-on-open.spec.ts
+++ b/tests/e2e/no-errors-on-open.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, assertNoRuntimeErrors } from './lib'
+import { openFixture } from './helpers'
+import { focusEditor } from './lib/actions'
+
+// Regression guard for the class of bug where code that runs on
+// document open throws or logs an error, but the test suite stays
+// green because individual feature tests only assert on their own
+// output.
+//
+// The `page` fixture (see `./lib/app.ts`) installs `pageerror` and
+// `console.error` listeners and fails on teardown if any runtime
+// error slipped through the allowlist. This spec is a minimal, deliberate
+// exercise of that guard: load a fixture, focus the editor, wait for
+// post-open async activity (semantic tokens, diagnostics, …), then
+// assert the collector is empty. Anything that throws or calls
+// `console.error` in renderer code during these steps will surface
+// here first, and the corresponding error is printed verbatim in the
+// failure message so the cause is obvious.
+test.describe('Runtime error sentinel', () => {
+  test('opening a .lex document produces no pageerror or console.error', async ({
+    page,
+    runtimeErrors,
+  }) => {
+    await openFixture(page, 'semantic-basic.lex')
+    await focusEditor(page)
+
+    // Poll for the editor + semantic tokens to settle. Anything that
+    // was going to throw during mount / LSP attach / first render has
+    // had a chance by this point.
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const active = (window as any).lexTest?.getActiveEditorValue?.() as string | undefined
+          return typeof active === 'string' && active.length > 0
+        })
+      )
+      .toBe(true)
+
+    // Allow a further tick so any async error that fires from a
+    // promise chain kicked off by `editor.setModel` gets the chance
+    // to land before we inspect the collector.
+    await page.waitForTimeout(250)
+
+    assertNoRuntimeErrors(runtimeErrors, 'opening a .lex document')
+  })
+})


### PR DESCRIPTION
## Motivation

After the recent nvim `semantic_tokens.enable` regression (see lex-fmt/nvim#21) the same meta-question applies to lexed: does the e2e suite watch the renderer's error channels, or only assert on success paths? Answer: only success paths. A component mount that `console.error`s and recovers, an unhandled promise rejection from `ensureLspInitialized`, or a provider registration that throws and is caught by Playwright's default error handler all sail through CI today.

This PR closes that gap.

## What lands

- `tests/e2e/lib/app.ts` grows a `runtimeErrors` Playwright fixture marked `auto: true`. It installs `pageerror` and `console` (error-level) listeners on the page for every test, collects messages into a per-test array, and on teardown fails any passing test where the array is non-empty. If the test body already failed the fixture re-throws the original failure so the reported cause stays meaningful.
- `tests/e2e/lib/assertions.ts` gets `assertNoRuntimeErrors(errors, ctx)` for specs that want to check mid-run rather than wait for teardown.
- `tests/e2e/lib/index.ts` re-exports the new helper.
- `tests/e2e/no-errors-on-open.spec.ts` is a dedicated sentinel: open a .lex fixture, focus the editor, let post-open activity settle, call `assertNoRuntimeErrors`. Minimal but covers the exact class of regression the motivating nvim bug represented.

## Red/green validation

Temporarily added `console.error('[lex] PROVOKED …')` to `semantic_tokens.ts::registerSemanticTokensProvider`:

- **Red**: 20 specs failed (auto-capture fired across the whole suite), every failure message included the offending text verbatim.
- **Green** after the provocation was reverted: **32/32 specs pass** with the new sentinel included, in both `test:e2e:dev` and the pre-commit-invoked `test:e2e:built` mode.

Pre-commit hook ran lint, typecheck, production build, and the full built-renderer e2e suite before accepting the commit.

## Allowlist (kept small — every entry has a TODO)

The harness immediately uncovered two pre-existing issues on the lexed side. Rather than blocking the harness on fixing them, they're allowlisted with a TODO so they become tracked separately and the guard lands now:

- `Invalid Semantic Tokens Data From Extension` — `lex-lsp` occasionally emits a semantic token whose `end` column exceeds the line's length; Monaco logs it. Observed on `preview.spec.ts` → `general.lex`.
- `Failed to load resource: net::ERR_FILE_NOT_FOUND` — the built renderer references an asset that doesn't ship in `dist/`. Only fires under `LEX_E2E_USE_BUILD=1`.

Plus the standard infrastructure noise (Chromium Autofill devtools messages, React DevTools banner).

## Cross-repo parallel

The same pattern lands in nvim as lex-fmt/nvim#21. A matching PR for vscode is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)