### PR TITLE
Bump pinned LSP version to v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 - `shared/lex-deps.json` key changed from `lex-lsp` to `lexd-lsp`
 
 Updates all references to the renamed binary: electron-builder config, fetch-deps.sh, lsp-manager, QuickLook extension, e2e helpers, and documentation.
+
+### Changed
+
+- Bumped pinned LSP version to v0.8.5 (picks up the table-scoped footnote resolver fix from lex-fmt/lex#460 and the rowspan diagnostic fix from lex-fmt/lex#458).

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.8.3",
+      "version": "v0.8.5",
       "repo": "lex-fmt/lex"
     }
   }


### PR DESCRIPTION
## Summary

Bumps the pinned `lexd-lsp` version from `v0.8.3` to `v0.8.5`.

### Fixes picked up

- `missing-footnote` diagnostic false-positives on numbered references inside a table cell when the definition is the table's own positional footnote list (lex-fmt/lex#460).
- `table-inconsistent-columns` diagnostic false-positives on rows whose column count is reduced by `^^` rowspan markers (lex-fmt/lex#458).
- Diagnostic message reworded from "no matching item in a `:: notes ::` list" to the scope-agnostic "no matching footnote definition in scope".

## Test plan

- [x] `shared/lex-deps.json` pins v0.8.5.
- [x] CHANGELOG updated.
- [ ] CI downloads the v0.8.5 `lexd-lsp` binary and runs the editor's test suite against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)