### PR TITLE
Fix Windows release: stop exporting empty CSC_LINK on non-macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,14 +105,28 @@ jobs:
         if: ${{ steps.target-filter.outputs.skip == 'false' }}
         run: npm ci
 
-      - name: Build Electron package
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
+      # Split the build step in two so CSC_LINK / CSC_KEY_PASSWORD are only
+      # *defined* on macOS. Setting them to "" on Windows/Linux still creates
+      # the env var and trips electron-builder's Windows signing path, which
+      # reads CSC_LINK (alias WIN_CSC_LINK), tries to resolve the empty
+      # string as a file path under the runner workspace, and fails with
+      # "Env WIN_CSC_LINK is not correct, cannot resolve: D:\a\... not a file".
+      - name: Build Electron package (macOS, signed)
+        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEX_HIDE_WINDOW: "1"
           NODE_OPTIONS: --max-old-space-size=4096
-          CSC_LINK: ${{ startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE_P12_BASE64 || '' }}
-          CSC_KEY_PASSWORD: ${{ startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: npm run build
+
+      - name: Build Electron package (unsigned)
+        if: ${{ steps.target-filter.outputs.skip == 'false' && !startsWith(matrix.platform, 'macos-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEX_HIDE_WINDOW: "1"
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build
 
       - name: Re-sign QuickLook plugin and re-create DMG


### PR DESCRIPTION
## Problem

Every lexed release since v0.6.1 has had its Windows build fail with:

```
⨯ Env WIN_CSC_LINK is not correct, cannot resolve: D:\a\***\*** not a file
```

(The `***\***` is GitHub Actions masking the org/repo name in the runner workspace path `D:\a\lex-fmt\lexed`.)

## Root cause

Commit `dd52659` ("Add macOS code signing and notarization to release workflow") added conditional signing env vars via:

```yaml
CSC_LINK: ${{ startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE_P12_BASE64 || '' }}
CSC_KEY_PASSWORD: ${{ startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
```

On Windows and Linux this evaluates to `''`, but YAML `env:` blocks still **define** the variable when the value is the empty string. electron-builder 24 then sees `CSC_LINK` defined (alias `WIN_CSC_LINK` on Windows), reads it as "signing requested", and tries to resolve the empty string as a path. `path.resolve("", cwd)` returns the runner workspace, which is a directory, so the error is "not a file".

## Fix

Split the `Build Electron package` step into two mutually-exclusive steps:

- **macOS, signed** — runs on `macos-*` runners with `CSC_LINK` and `CSC_KEY_PASSWORD` set from the Apple cert secrets.
- **unsigned** — runs on everything else, with those env vars not present at all.

Windows and Linux have no code-signing wired up (we don't ship certs for them yet), so producing unsigned binaries is the intended behaviour there.

## Test plan

- [ ] CI on this PR exercises the branch on `main`-style tags (workflow only runs on `v*` tag pushes and `workflow_dispatch`), so it won't fully rerun until the fix merges and we re-trigger v0.6.4 via `workflow_dispatch` with `tag=v0.6.4 target=windows-x64` — or wait for the next tag.
- [ ] Post-merge: manually dispatch the release workflow against v0.6.4 with `target=windows-x64` to backfill the missing Windows asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)