### PR TITLE
Route OS-opened files to the best-matching window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,14 @@ Updates all references to the renamed binary: electron-builder config, fetch-dep
 ### Changed
 
 - Bumped pinned LSP version to v0.8.5 (picks up the table-scoped footnote resolver fix from lex-fmt/lex#460 and the rowspan diagnostic fix from lex-fmt/lex#458).
+
+### Added
+
+- Per-window workspace roots are now persisted across relaunches. A brand-new window picking a folder via File → Open Folder correctly writes its root into the store instead of silently dropping the IPC (previously the write was skipped whenever the window had no pre-existing entry in `openWindows`). Same upsert fix applied to the pane-layout IPC.
+- Track a rolling `recentRoots` history in global settings — populated whenever a folder becomes a window's root (explicit open, initial-folder restore, CLI argument, first-launch welcome path). Capped at 20, deduped case-appropriately per-platform.
+- OS-opened files now route to the best-matching window instead of always `windows[0]`. Decision order: open window whose root contains the file (longest match, tie-break on focus/recency) → new window with a matching recent root → focused/most-recent open window → new window. Fixes the "file silently doesn't appear" symptom when Finder-opening a file outside the first window's workspace. macOS `open-file` events arriving before the app is ready are queued and dispatched once the router has context.
+
+### Fixed
+
+- `saveWindowState` no longer clobbers fresh window bounds with stale ones (spread order was reversed, so geometry never updated across launches).
+- Dev-mode argv parsing no longer misreads the Electron bootstrap argument (`electron .`) as a user-requested workspace folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,5 @@ Updates all references to the renamed binary: electron-builder config, fetch-dep
 
 - `saveWindowState` no longer clobbers fresh window bounds with stale ones (spread order was reversed, so geometry never updated across launches).
 - Dev-mode argv parsing no longer misreads the Electron bootstrap argument (`electron .`) as a user-requested workspace folder.
+- Cap window restoration at 10 entries on launch. Quit/crash paths could leave orphaned `openWindows` entries in the store; without a cap, a machine used long enough would spawn a growing number of windows on every launch.
+- New windows created by OS-file routing seed their initial pane layout into the store before load, so the file reliably appears as a tab instead of racing with renderer-side IPC listener registration.

--- a/electron/file-routing.test.ts
+++ b/electron/file-routing.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isCaseSensitiveFs,
+  isPathInsideRoot,
+  findBestRoot,
+  routeOpenFile,
+  updateRecentRoots,
+  type OpenWindowState,
+  type RecentRoot,
+} from './file-routing'
+
+describe('isCaseSensitiveFs', () => {
+  it('treats linux as case-sensitive', () => {
+    expect(isCaseSensitiveFs('linux')).toBe(true)
+  })
+
+  it('treats darwin as case-insensitive', () => {
+    expect(isCaseSensitiveFs('darwin')).toBe(false)
+  })
+
+  it('treats win32 as case-insensitive', () => {
+    expect(isCaseSensitiveFs('win32')).toBe(false)
+  })
+})
+
+describe('isPathInsideRoot', () => {
+  it('returns true for file directly inside root', () => {
+    expect(isPathInsideRoot('/Users/alice/docs/a.lex', '/Users/alice/docs', 'darwin')).toBe(true)
+  })
+
+  it('returns true for deeply nested file', () => {
+    expect(
+      isPathInsideRoot('/Users/alice/docs/nested/deep/a.lex', '/Users/alice/docs', 'darwin')
+    ).toBe(true)
+  })
+
+  it('returns true when path equals root', () => {
+    expect(isPathInsideRoot('/Users/alice/docs', '/Users/alice/docs', 'darwin')).toBe(true)
+  })
+
+  it('returns false for sibling paths with shared prefix', () => {
+    expect(isPathInsideRoot('/Users/alice/docs2/a.lex', '/Users/alice/docs', 'darwin')).toBe(false)
+  })
+
+  it('returns false when path is outside root', () => {
+    expect(isPathInsideRoot('/tmp/a.lex', '/Users/alice/docs', 'darwin')).toBe(false)
+  })
+
+  it('returns false for empty root or path', () => {
+    expect(isPathInsideRoot('', '/a', 'linux')).toBe(false)
+    expect(isPathInsideRoot('/a/b', '', 'linux')).toBe(false)
+  })
+
+  it('handles trailing slash on root', () => {
+    expect(isPathInsideRoot('/root/a.lex', '/root/', 'linux')).toBe(true)
+  })
+
+  it('is case-insensitive on darwin', () => {
+    expect(isPathInsideRoot('/USERS/Alice/Docs/a.lex', '/users/alice/docs', 'darwin')).toBe(true)
+  })
+
+  it('is case-insensitive on win32', () => {
+    expect(isPathInsideRoot('/USERS/Alice/Docs/a.lex', '/users/alice/docs', 'win32')).toBe(true)
+  })
+
+  it('is case-sensitive on linux', () => {
+    expect(isPathInsideRoot('/Users/Alice/docs/a.lex', '/users/alice/docs', 'linux')).toBe(false)
+    expect(isPathInsideRoot('/users/alice/docs/a.lex', '/users/alice/docs', 'linux')).toBe(true)
+  })
+
+  it('normalizes relative segments', () => {
+    expect(isPathInsideRoot('/a/b/../b/c.lex', '/a/b', 'linux')).toBe(true)
+    expect(isPathInsideRoot('/a/b/../../c.lex', '/a/b', 'linux')).toBe(false)
+  })
+})
+
+describe('findBestRoot', () => {
+  it('returns null when no candidate matches', () => {
+    const result = findBestRoot(
+      '/foo/a.lex',
+      [{ root: '/bar' }, { root: '/baz' }],
+      (c) => c.root,
+      () => 0,
+      'linux'
+    )
+    expect(result).toBeNull()
+  })
+
+  it('returns the only candidate when just one matches', () => {
+    const result = findBestRoot(
+      '/project/a.lex',
+      [{ root: '/project' }, { root: '/other' }],
+      (c) => c.root,
+      () => 0,
+      'linux'
+    )
+    expect(result?.root).toBe('/project')
+  })
+
+  it('picks the longest (most-specific) matching root', () => {
+    const result = findBestRoot(
+      '/project/sub/a.lex',
+      [{ root: '/project' }, { root: '/project/sub' }],
+      (c) => c.root,
+      () => 0,
+      'linux'
+    )
+    expect(result?.root).toBe('/project/sub')
+  })
+
+  it('breaks ties by the tiebreaker score', () => {
+    const result = findBestRoot(
+      '/project/a.lex',
+      [
+        { root: '/project', score: 10 },
+        { root: '/project', score: 100 },
+        { root: '/project', score: 5 },
+      ],
+      (c) => c.root,
+      (c) => c.score,
+      'linux'
+    )
+    expect(result?.score).toBe(100)
+  })
+
+  it('skips candidates with null roots', () => {
+    const result = findBestRoot(
+      '/project/a.lex',
+      [{ root: null }, { root: '/project' }],
+      (c) => c.root,
+      () => 0,
+      'linux'
+    )
+    expect(result?.root).toBe('/project')
+  })
+})
+
+describe('routeOpenFile', () => {
+  const empty: RecentRoot[] = []
+
+  it('creates a new window when no windows are open', () => {
+    const route = routeOpenFile({
+      filePath: '/docs/a.lex',
+      openWindows: [],
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toEqual({ kind: 'newWindow', filePath: '/docs/a.lex' })
+  })
+
+  it('picks an open window whose root contains the file', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/elsewhere' },
+      { windowId: 2, root: '/docs' },
+    ]
+    const route = routeOpenFile({
+      filePath: '/docs/a.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toEqual({ kind: 'existingWindow', windowId: 2, filePath: '/docs/a.lex' })
+  })
+
+  it('prefers the longest matching open root', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/docs' },
+      { windowId: 2, root: '/docs/sub' },
+    ]
+    const route = routeOpenFile({
+      filePath: '/docs/sub/a.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
+  })
+
+  it('among equally-specific open roots, prefers the focused window', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/docs', lastFocusedAt: 10 },
+      { windowId: 2, root: '/docs', lastFocusedAt: 5, isFocused: true },
+    ]
+    const route = routeOpenFile({
+      filePath: '/docs/a.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
+  })
+
+  it('among equally-specific open roots with no focus, prefers most-recently-focused', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/docs', lastFocusedAt: 10 },
+      { windowId: 2, root: '/docs', lastFocusedAt: 50 },
+      { windowId: 3, root: '/docs', lastFocusedAt: 5 },
+    ]
+    const route = routeOpenFile({
+      filePath: '/docs/a.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
+  })
+
+  it('falls back to a recent root if no open window matches', () => {
+    const windows: OpenWindowState[] = [{ windowId: 1, root: '/unrelated' }]
+    const recent: RecentRoot[] = [
+      { path: '/projects/old', lastUsedAt: 1 },
+      { path: '/projects/notes', lastUsedAt: 2 },
+    ]
+    const route = routeOpenFile({
+      filePath: '/projects/notes/a.lex',
+      openWindows: windows,
+      recentRoots: recent,
+      platform: 'linux',
+    })
+    expect(route).toEqual({
+      kind: 'newWindowWithRoot',
+      root: '/projects/notes',
+      filePath: '/projects/notes/a.lex',
+    })
+  })
+
+  it('among equally-specific recent roots, picks the most recently used', () => {
+    const recent: RecentRoot[] = [
+      { path: '/projects/notes', lastUsedAt: 10 },
+      { path: '/projects/notes', lastUsedAt: 100 },
+    ]
+    const route = routeOpenFile({
+      filePath: '/projects/notes/a.lex',
+      openWindows: [],
+      recentRoots: recent,
+      platform: 'linux',
+    })
+    // newWindowWithRoot is the right kind since no windows are open
+    expect(route.kind).toBe('newWindowWithRoot')
+  })
+
+  it('prefers an open match over a recent match', () => {
+    const windows: OpenWindowState[] = [{ windowId: 1, root: '/projects/notes' }]
+    const recent: RecentRoot[] = [{ path: '/projects/notes', lastUsedAt: 100 }]
+    const route = routeOpenFile({
+      filePath: '/projects/notes/a.lex',
+      openWindows: windows,
+      recentRoots: recent,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
+  })
+
+  it('falls back to focused open window when no root matches', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/projects/a', lastFocusedAt: 10 },
+      { windowId: 2, root: '/projects/b', lastFocusedAt: 50, isFocused: true },
+    ]
+    const route = routeOpenFile({
+      filePath: '/tmp/orphan.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
+  })
+
+  it('falls back to most-recently-focused open window when no focus flag is set', () => {
+    const windows: OpenWindowState[] = [
+      { windowId: 1, root: '/projects/a', lastFocusedAt: 10 },
+      { windowId: 2, root: '/projects/b', lastFocusedAt: 50 },
+    ]
+    const route = routeOpenFile({
+      filePath: '/tmp/orphan.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
+  })
+
+  it('treats windows with no root as non-matching but still valid fallback targets', () => {
+    const windows: OpenWindowState[] = [{ windowId: 1, root: null, lastFocusedAt: 1 }]
+    const route = routeOpenFile({
+      filePath: '/tmp/orphan.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'linux',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
+  })
+
+  it('honors platform case-insensitivity on darwin', () => {
+    const windows: OpenWindowState[] = [{ windowId: 1, root: '/Users/Alice/Docs' }]
+    const route = routeOpenFile({
+      filePath: '/users/alice/docs/a.lex',
+      openWindows: windows,
+      recentRoots: empty,
+      platform: 'darwin',
+    })
+    expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
+  })
+})
+
+describe('updateRecentRoots', () => {
+  it('inserts a new root at the front', () => {
+    const result = updateRecentRoots([], '/projects/new', 100, 20, 'linux')
+    expect(result).toEqual([{ path: '/projects/new', lastUsedAt: 100 }])
+  })
+
+  it('deduplicates same root, updating timestamp', () => {
+    const existing: RecentRoot[] = [{ path: '/projects/a', lastUsedAt: 10 }]
+    const result = updateRecentRoots(existing, '/projects/a', 50, 20, 'linux')
+    expect(result).toEqual([{ path: '/projects/a', lastUsedAt: 50 }])
+  })
+
+  it('keeps list sorted by lastUsedAt descending', () => {
+    const existing: RecentRoot[] = [
+      { path: '/projects/a', lastUsedAt: 10 },
+      { path: '/projects/b', lastUsedAt: 30 },
+    ]
+    const result = updateRecentRoots(existing, '/projects/c', 20, 20, 'linux')
+    expect(result.map((r) => r.path)).toEqual(['/projects/b', '/projects/c', '/projects/a'])
+  })
+
+  it('caps the list to `max` entries', () => {
+    const existing: RecentRoot[] = Array.from({ length: 5 }, (_, i) => ({
+      path: `/p${i}`,
+      lastUsedAt: i,
+    }))
+    const result = updateRecentRoots(existing, '/new', 100, 3, 'linux')
+    expect(result).toHaveLength(3)
+    expect(result[0].path).toBe('/new')
+  })
+
+  it('deduplicates case-insensitively on darwin', () => {
+    const existing: RecentRoot[] = [{ path: '/Projects/Notes', lastUsedAt: 1 }]
+    const result = updateRecentRoots(existing, '/projects/notes', 50, 20, 'darwin')
+    expect(result).toHaveLength(1)
+    expect(result[0].lastUsedAt).toBe(50)
+  })
+
+  it('does not deduplicate case-insensitively on linux', () => {
+    const existing: RecentRoot[] = [{ path: '/Projects/Notes', lastUsedAt: 1 }]
+    const result = updateRecentRoots(existing, '/projects/notes', 50, 20, 'linux')
+    expect(result).toHaveLength(2)
+  })
+
+  it('ignores empty newRoot', () => {
+    const existing: RecentRoot[] = [{ path: '/p', lastUsedAt: 1 }]
+    const result = updateRecentRoots(existing, '', 50, 20, 'linux')
+    expect(result).toBe(existing)
+  })
+})

--- a/electron/file-routing.ts
+++ b/electron/file-routing.ts
@@ -1,0 +1,170 @@
+import path from 'node:path'
+
+export interface OpenWindowState {
+  windowId: number
+  root: string | null | undefined
+  lastFocusedAt?: number
+  isFocused?: boolean
+}
+
+export interface RecentRoot {
+  path: string
+  lastUsedAt: number
+}
+
+export type OpenFileRoute =
+  | { kind: 'existingWindow'; windowId: number; filePath: string }
+  | { kind: 'newWindowWithRoot'; root: string; filePath: string }
+  | { kind: 'newWindow'; filePath: string }
+
+export interface RouteOpenFileParams {
+  filePath: string
+  openWindows: OpenWindowState[]
+  recentRoots: RecentRoot[]
+  platform?: typeof process.platform
+}
+
+export function isCaseSensitiveFs(platform: typeof process.platform): boolean {
+  return platform === 'linux' || platform === 'freebsd' || platform === 'openbsd'
+}
+
+function normalizeForCompare(p: string, caseSensitive: boolean): string {
+  const resolved = path.resolve(p)
+  return caseSensitive ? resolved : resolved.toLowerCase()
+}
+
+/**
+ * Is `filePath` inside `root` (or equal to it)?
+ *
+ * Uses platform-appropriate case sensitivity unless overridden.
+ */
+export function isPathInsideRoot(
+  filePath: string,
+  root: string,
+  platform: typeof process.platform = process.platform
+): boolean {
+  if (!filePath || !root) return false
+  const caseSensitive = isCaseSensitiveFs(platform)
+  const a = normalizeForCompare(filePath, caseSensitive)
+  const b = normalizeForCompare(root, caseSensitive)
+  if (a === b) return true
+  const bWithSep = b.endsWith(path.sep) ? b : b + path.sep
+  return a.startsWith(bWithSep)
+}
+
+/**
+ * Pick the most specific (longest) root from `candidates` that contains `filePath`.
+ * Ties broken by `tiebreak` (higher score wins). Returns null if none match.
+ */
+export function findBestRoot<T>(
+  filePath: string,
+  candidates: T[],
+  getRoot: (c: T) => string | null | undefined,
+  tiebreak: (c: T) => number,
+  platform: typeof process.platform = process.platform
+): T | null {
+  let best: T | null = null
+  let bestLen = -1
+  let bestScore = -Infinity
+  for (const c of candidates) {
+    const root = getRoot(c)
+    if (!root) continue
+    if (!isPathInsideRoot(filePath, root, platform)) continue
+    const len = root.length
+    const score = tiebreak(c)
+    if (len > bestLen || (len === bestLen && score > bestScore)) {
+      best = c
+      bestLen = len
+      bestScore = score
+    }
+  }
+  return best
+}
+
+/**
+ * Decide where to route a file the OS wants us to open.
+ *
+ * Strategy:
+ *   1. If any open window's root contains the file → open it there (best = longest root,
+ *      ties broken by recency / focus).
+ *   2. Else if any recent (closed) root contains the file → open a new window with that root.
+ *   3. Else if at least one window is open → open the file in the focused window (or the
+ *      most-recently-focused one, or the first one).
+ *   4. Else → create a new window with no specific root for the file.
+ */
+export function routeOpenFile(params: RouteOpenFileParams): OpenFileRoute {
+  const { filePath, openWindows, recentRoots, platform = process.platform } = params
+
+  const bestOpen = findBestRoot(
+    filePath,
+    openWindows,
+    (w) => w.root,
+    (w) => (w.isFocused ? Number.MAX_SAFE_INTEGER : (w.lastFocusedAt ?? 0)),
+    platform
+  )
+  if (bestOpen) {
+    return { kind: 'existingWindow', windowId: bestOpen.windowId, filePath }
+  }
+
+  const bestRecent = findBestRoot(
+    filePath,
+    recentRoots,
+    (r) => r.path,
+    (r) => r.lastUsedAt,
+    platform
+  )
+  if (bestRecent) {
+    return { kind: 'newWindowWithRoot', root: bestRecent.path, filePath }
+  }
+
+  if (openWindows.length > 0) {
+    const fallback = pickFallbackWindow(openWindows)
+    if (fallback) {
+      return { kind: 'existingWindow', windowId: fallback.windowId, filePath }
+    }
+  }
+
+  return { kind: 'newWindow', filePath }
+}
+
+function pickFallbackWindow(openWindows: OpenWindowState[]): OpenWindowState | null {
+  if (openWindows.length === 0) return null
+  const focused = openWindows.find((w) => w.isFocused)
+  if (focused) return focused
+  let best: OpenWindowState | null = null
+  let bestAt = -Infinity
+  for (const w of openWindows) {
+    const at = w.lastFocusedAt ?? 0
+    if (at > bestAt) {
+      best = w
+      bestAt = at
+    }
+  }
+  return best ?? openWindows[0]
+}
+
+/**
+ * Merge a new root into the recent-roots list. Deduplicates by path
+ * (case-sensitivity-aware) and returns a list sorted by lastUsedAt descending,
+ * capped at `max`.
+ */
+export function updateRecentRoots(
+  existing: RecentRoot[],
+  newRoot: string,
+  now: number,
+  max: number = 20,
+  platform: typeof process.platform = process.platform
+): RecentRoot[] {
+  if (!newRoot) return existing
+  const caseSensitive = isCaseSensitiveFs(platform)
+  const resolved = path.resolve(newRoot)
+  const key = caseSensitive ? resolved : resolved.toLowerCase()
+  const filtered = existing.filter((r) => {
+    const resolvedExisting = path.resolve(r.path)
+    const existingKey = caseSensitive ? resolvedExisting : resolvedExisting.toLowerCase()
+    return existingKey !== key
+  })
+  filtered.unshift({ path: resolved, lastUsedAt: now })
+  filtered.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+  return filtered.slice(0, max)
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,7 +22,7 @@ import {
   type OpenWindowState,
   type RecentRoot,
 } from './file-routing'
-import { setWindowFolder, setWindowPaneLayout } from './window-state'
+import { setWindowFolder, setWindowPaneLayout, upsertWindowState } from './window-state'
 import { randomUUID } from 'crypto'
 
 const DEFAULT_WINDOW_BOUNDS = { width: 1200, height: 800 }
@@ -249,6 +249,7 @@ function collectOpenWindowStates(): OpenWindowState[] {
       windowId: win.id,
       root: state?.lastFolder ?? null,
       isFocused: focused?.id === win.id,
+      lastFocusedAt: windowManager.getLastFocusedAt(win.id),
     }
   })
 }
@@ -398,6 +399,13 @@ function extractPathsFromArgv(argv: string[]): CliPaths {
   return { files, folder }
 }
 
+export interface FileRouteDestination {
+  filePath: string
+  kind: 'existingWindow' | 'newWindowWithRoot' | 'newWindow'
+  windowId: number
+  root?: string
+}
+
 /**
  * Route each OS-provided file to the most appropriate window:
  *   1. An open window whose workspace root contains the file (best = longest root).
@@ -407,22 +415,26 @@ function extractPathsFromArgv(argv: string[]): CliPaths {
  *
  * This is what fixes the "silently does nothing" behaviour when the OS hands
  * us a file that lives outside whatever window happened to be windows[0].
+ *
+ * Returns a per-file record of the destination window so callers (tests in
+ * particular) can assert where each file landed.
  */
-function openFilesViaRouter(filePaths: string[]) {
-  if (filePaths.length === 0) return
+async function openFilesViaRouter(filePaths: string[]): Promise<FileRouteDestination[]> {
+  if (filePaths.length === 0) return []
 
-  // Group files per destination so we don't create one window per file when
+  // Snapshot routing inputs once — they don't change within a single batch,
+  // and recomputing per-file would make decisions harder to reason about.
+  const openWindows = collectOpenWindowStates()
+  const recentRoots = getRecentRoots()
+
+  // Group files per destination so we don't spawn one window per file when
   // several files share the same routing decision.
   const toExistingWindow = new Map<number, string[]>()
   const toNewWindowWithRoot = new Map<string, string[]>()
   const toNewWindow: string[] = []
 
   for (const filePath of filePaths) {
-    const route = routeOpenFile({
-      filePath,
-      openWindows: collectOpenWindowStates(),
-      recentRoots: getRecentRoots(),
-    })
+    const route = routeOpenFile({ filePath, openWindows, recentRoots })
     switch (route.kind) {
       case 'existingWindow': {
         const list = toExistingWindow.get(route.windowId) ?? []
@@ -442,12 +454,15 @@ function openFilesViaRouter(filePaths: string[]) {
     }
   }
 
+  const destinations: FileRouteDestination[] = []
+
   for (const [windowId, files] of toExistingWindow) {
     const win = BrowserWindow.fromId(windowId)
     if (!win || win.isDestroyed()) continue
     for (const file of files) {
       win.webContents.send('open-file-path', file)
       app.addRecentDocument(file)
+      destinations.push({ filePath: file, kind: 'existingWindow', windowId })
     }
     if (win.isMinimized()) win.restore()
     win.focus()
@@ -455,25 +470,76 @@ function openFilesViaRouter(filePaths: string[]) {
 
   for (const [root, files] of toNewWindowWithRoot) {
     recordRecentRoot(root)
-    windowManager.createWindow(
+    const newStateId = randomUUID()
+    seedNewWindowState(newStateId, files, root)
+    const win = await windowManager.createWindow(
       {
-        id: randomUUID(),
+        id: newStateId,
         width: DEFAULT_WINDOW_BOUNDS.width,
         height: DEFAULT_WINDOW_BOUNDS.height,
         lastFolder: root,
       },
-      { showSplash: true, openFiles: files }
+      { showSplash: true }
     )
-    files.forEach((f) => app.addRecentDocument(f))
+    files.forEach((f) => {
+      app.addRecentDocument(f)
+      destinations.push({ filePath: f, kind: 'newWindowWithRoot', windowId: win.id, root })
+    })
   }
 
   if (toNewWindow.length > 0) {
-    windowManager.createWindow(undefined, {
-      showSplash: true,
-      openFiles: toNewWindow,
+    const newStateId = randomUUID()
+    seedNewWindowState(newStateId, toNewWindow, null)
+    const win = await windowManager.createWindow(
+      {
+        id: newStateId,
+        width: DEFAULT_WINDOW_BOUNDS.width,
+        height: DEFAULT_WINDOW_BOUNDS.height,
+      },
+      { showSplash: true }
+    )
+    toNewWindow.forEach((f) => {
+      app.addRecentDocument(f)
+      destinations.push({ filePath: f, kind: 'newWindow', windowId: win.id })
     })
-    toNewWindow.forEach((f) => app.addRecentDocument(f))
   }
+
+  return destinations
+}
+
+/**
+ * Seed a newly-created window's persisted state with its workspace root and
+ * an initial pane layout that already contains the files to be opened.
+ *
+ * Going through the store avoids the race where `did-finish-load` → `send('open-file-path')`
+ * can fire before the renderer registers its listener (files silently dropped).
+ * The renderer loads this state via `get-open-tabs` on mount — deterministic.
+ */
+function seedNewWindowState(stateId: string, files: string[], root: string | null): void {
+  const paneId = randomUUID()
+  const rowId = randomUUID()
+  const paneLayout = [
+    {
+      id: paneId,
+      tabs: files,
+      activeTab: files[files.length - 1] ?? null,
+    },
+  ]
+  const paneRows = [{ id: rowId, paneIds: [paneId] }]
+  const patch: Partial<import('./window-manager').WindowState> = {
+    paneLayout,
+    paneRows,
+    activePaneId: paneId,
+  }
+  if (root) patch.lastFolder = root
+  const openWindows = store.store.openWindows || []
+  store.set(
+    'openWindows',
+    upsertWindowState(openWindows, stateId, patch, {
+      width: DEFAULT_WINDOW_BOUNDS.width,
+      height: DEFAULT_WINDOW_BOUNDS.height,
+    })
+  )
 }
 
 /**
@@ -625,20 +691,11 @@ ipcMain.handle('test-set-workspace', async (_, folderPath: string) => {
 
 /**
  * Test-only: simulate an OS-level file-open event (macOS `open-file` or
- * Windows/Linux second-instance) by running the router directly. Returns the
- * IDs of the windows that received each file so e2e tests can assert where
- * each file landed.
+ * Windows/Linux second-instance) by running the router directly. Returns a
+ * per-file destination record so e2e tests can assert where each file landed.
  */
 ipcMain.handle('test-route-open-files', async (_, filePaths: string[]) => {
-  const before = new Set(windowManager.getAllWindows().map((w) => w.id))
-  openFilesViaRouter(filePaths)
-  // Give createWindow a tick to register new windows
-  await new Promise((resolve) => setTimeout(resolve, 50))
-  const after = windowManager.getAllWindows().map((w) => w.id)
-  return {
-    existingWindowIds: after.filter((id) => before.has(id)),
-    newWindowIds: after.filter((id) => !before.has(id)),
-  }
+  return openFilesViaRouter(filePaths)
 })
 
 ipcMain.handle('file-read-dir', async (_, dirPath: string) => {
@@ -1567,7 +1624,7 @@ if (!gotTheLock) {
       // files through the normal logic.
       openCliPaths(cliPaths)
     } else if (cliPaths.files.length > 0) {
-      openFilesViaRouter(cliPaths.files)
+      void openFilesViaRouter(cliPaths.files)
     } else {
       // No paths, just focus the existing window
       const windows = windowManager.getAllWindows()
@@ -1591,7 +1648,7 @@ if (!gotTheLock) {
       pendingOpenFiles.push(filePath)
       return
     }
-    openFilesViaRouter([filePath])
+    void openFilesViaRouter([filePath])
   })
 
   app.whenReady().then(async () => {
@@ -1697,7 +1754,7 @@ if (!gotTheLock) {
     appIsReady = true
     if (pendingOpenFiles.length > 0) {
       const queued = pendingOpenFiles.splice(0, pendingOpenFiles.length)
-      openFilesViaRouter(queued)
+      void openFilesViaRouter(queued)
     }
   })
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,7 +16,16 @@ import {
   FormatterSettings,
   FileTreeSettings,
 } from './window-manager'
+import {
+  routeOpenFile,
+  updateRecentRoots,
+  type OpenWindowState,
+  type RecentRoot,
+} from './file-routing'
+import { setWindowFolder, setWindowPaneLayout } from './window-state'
 import { randomUUID } from 'crypto'
+
+const DEFAULT_WINDOW_BOUNDS = { width: 1200, height: 800 }
 // LspManager import removed as it is managed by WindowManager
 
 // Configure logging
@@ -139,6 +148,16 @@ const store = new Store<AppSettings>({
         },
       },
     },
+    recentRoots: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          lastUsedAt: { type: 'number' },
+        },
+      },
+    },
     editor: {
       type: 'object',
       properties: {
@@ -200,6 +219,39 @@ const store = new Store<AppSettings>({
 
 // Initialize WindowManager after store is created
 const windowManager = new WindowManager(store)
+
+const MAX_RECENT_ROOTS = 20
+
+function recordRecentRoot(folderPath: string | null | undefined): void {
+  if (!folderPath) return
+  const existing = store.store.recentRoots ?? []
+  const updated = updateRecentRoots(existing, folderPath, Date.now(), MAX_RECENT_ROOTS)
+  store.set('recentRoots', updated)
+}
+
+function getRecentRoots(): RecentRoot[] {
+  return store.store.recentRoots ?? []
+}
+
+/**
+ * Build the list of currently-open windows along with their workspace roots,
+ * for the file router. The focused window (if any) is flagged so ties resolve
+ * in its favor.
+ */
+function collectOpenWindowStates(): OpenWindowState[] {
+  const settings = store.store
+  const openWindowState = settings.openWindows ?? []
+  const focused = BrowserWindow.getFocusedWindow()
+  return windowManager.getAllWindows().map((win) => {
+    const stateId = windowManager.getWindowStateId(win.id)
+    const state = stateId ? openWindowState.find((w) => w.id === stateId) : undefined
+    return {
+      windowId: win.id,
+      root: state?.lastFolder ?? null,
+      isFocused: focused?.id === win.id,
+    }
+  })
+}
 
 // Settings persistence helpers removed in favor of direct store access or WindowManager
 // loadSettings, saveSettings, etc. are no longer used directly in main.ts logic
@@ -303,12 +355,16 @@ interface CliPaths {
  * Returns files to open and an optional folder to set as workspace.
  */
 function extractPathsFromArgv(argv: string[]): CliPaths {
+  // In dev mode the bootstrap arg is the app directory itself (e.g. `electron .`).
+  // Ignore it so we don't misread the repo root as a user-requested workspace.
+  const appPath = app.isReady() ? app.getAppPath() : null
   const paths = argv
     .filter((arg) => !arg.startsWith('-') && !arg.startsWith('--'))
     .filter((arg) => {
       // Skip the electron binary and main script paths
       if (arg.includes('electron') || arg.includes('Electron')) return false
       if (arg.endsWith('.js') || arg.endsWith('.mjs')) return false
+      if (appPath && path.resolve(arg) === appPath) return false
       return true
     })
     .map((arg) => path.resolve(arg))
@@ -343,23 +399,80 @@ function extractPathsFromArgv(argv: string[]): CliPaths {
 }
 
 /**
- * Open files in the renderer by sending IPC messages.
- * If no windows exist, creates a new one.
+ * Route each OS-provided file to the most appropriate window:
+ *   1. An open window whose workspace root contains the file (best = longest root).
+ *   2. Otherwise, a new window created with a matching recent root.
+ *   3. Otherwise, the focused/most-recent open window (no root change).
+ *   4. Otherwise, a new window with no workspace root.
+ *
+ * This is what fixes the "silently does nothing" behaviour when the OS hands
+ * us a file that lives outside whatever window happened to be windows[0].
  */
-function openFilesInWindow(filePaths: string[]) {
+function openFilesViaRouter(filePaths: string[]) {
   if (filePaths.length === 0) return
 
-  const windows = windowManager.getAllWindows()
-  const targetWin = windows[0]
+  // Group files per destination so we don't create one window per file when
+  // several files share the same routing decision.
+  const toExistingWindow = new Map<number, string[]>()
+  const toNewWindowWithRoot = new Map<string, string[]>()
+  const toNewWindow: string[] = []
 
-  if (targetWin && !targetWin.isDestroyed()) {
-    for (const filePath of filePaths) {
-      targetWin.webContents.send('open-file-path', filePath)
-      app.addRecentDocument(filePath)
+  for (const filePath of filePaths) {
+    const route = routeOpenFile({
+      filePath,
+      openWindows: collectOpenWindowStates(),
+      recentRoots: getRecentRoots(),
+    })
+    switch (route.kind) {
+      case 'existingWindow': {
+        const list = toExistingWindow.get(route.windowId) ?? []
+        list.push(route.filePath)
+        toExistingWindow.set(route.windowId, list)
+        break
+      }
+      case 'newWindowWithRoot': {
+        const list = toNewWindowWithRoot.get(route.root) ?? []
+        list.push(route.filePath)
+        toNewWindowWithRoot.set(route.root, list)
+        break
+      }
+      case 'newWindow':
+        toNewWindow.push(route.filePath)
+        break
     }
-  } else {
-    // No windows exist, create a new one with the files
-    windowManager.createWindow(undefined, { showSplash: true, openFiles: filePaths })
+  }
+
+  for (const [windowId, files] of toExistingWindow) {
+    const win = BrowserWindow.fromId(windowId)
+    if (!win || win.isDestroyed()) continue
+    for (const file of files) {
+      win.webContents.send('open-file-path', file)
+      app.addRecentDocument(file)
+    }
+    if (win.isMinimized()) win.restore()
+    win.focus()
+  }
+
+  for (const [root, files] of toNewWindowWithRoot) {
+    recordRecentRoot(root)
+    windowManager.createWindow(
+      {
+        id: randomUUID(),
+        width: DEFAULT_WINDOW_BOUNDS.width,
+        height: DEFAULT_WINDOW_BOUNDS.height,
+        lastFolder: root,
+      },
+      { showSplash: true, openFiles: files }
+    )
+    files.forEach((f) => app.addRecentDocument(f))
+  }
+
+  if (toNewWindow.length > 0) {
+    windowManager.createWindow(undefined, {
+      showSplash: true,
+      openFiles: toNewWindow,
+    })
+    toNewWindow.forEach((f) => app.addRecentDocument(f))
   }
 }
 
@@ -373,6 +486,8 @@ function openCliPaths(cliPaths: CliPaths) {
 
   const windows = windowManager.getAllWindows()
   const targetWin = windows[0]
+
+  if (folder) recordRecentRoot(folder)
 
   if (targetWin && !targetWin.isDestroyed()) {
     // Set folder first if specified
@@ -508,6 +623,24 @@ ipcMain.handle('test-set-workspace', async (_, folderPath: string) => {
   return true
 })
 
+/**
+ * Test-only: simulate an OS-level file-open event (macOS `open-file` or
+ * Windows/Linux second-instance) by running the router directly. Returns the
+ * IDs of the windows that received each file so e2e tests can assert where
+ * each file landed.
+ */
+ipcMain.handle('test-route-open-files', async (_, filePaths: string[]) => {
+  const before = new Set(windowManager.getAllWindows().map((w) => w.id))
+  openFilesViaRouter(filePaths)
+  // Give createWindow a tick to register new windows
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const after = windowManager.getAllWindows().map((w) => w.id)
+  return {
+    existingWindowIds: after.filter((id) => before.has(id)),
+    newWindowIds: after.filter((id) => !before.has(id)),
+  }
+})
+
 ipcMain.handle('file-read-dir', async (_, dirPath: string) => {
   try {
     const entries = await fs.readdir(dirPath, { withFileTypes: true })
@@ -591,29 +724,37 @@ ipcMain.handle('get-initial-folder', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender)
   if (!win) return getWelcomeFolderPath()
 
+  const stateId = windowManager.getWindowStateId(win.id)
   const settings = store.store
-  // Find window state
-  const winState = settings.openWindows?.find(
-    (w) => w.id === windowManager.getWindowStateId(win.id)
-  )
+  const winState = settings.openWindows?.find((w) => w.id === stateId)
 
-  if (winState?.lastFolder) {
+  const resolve = async (candidate?: string) => {
+    if (!candidate) return null
     try {
-      await fs.access(winState.lastFolder)
-      return winState.lastFolder
+      await fs.access(candidate)
+      return candidate
     } catch {
-      // Folder no longer exists
+      return null
     }
   }
 
-  // Fallback to global lastFolder (legacy/migration) or welcome
-  if (settings.lastFolder) {
-    try {
-      await fs.access(settings.lastFolder)
-      return settings.lastFolder
-    } catch {
-      // Folder no longer exists
+  const resolved = (await resolve(winState?.lastFolder)) ?? (await resolve(settings.lastFolder))
+
+  if (resolved) {
+    // Write the resolved folder back onto the per-window entry so the
+    // association persists across launches (this covers windows restored
+    // from a bare session with only bounds) and record it in the recent
+    // roots history.
+    if (stateId) {
+      const openWindows = store.store.openWindows || []
+      store.set(
+        'openWindows',
+        setWindowFolder(openWindows, stateId, resolved, DEFAULT_WINDOW_BOUNDS)
+      )
     }
+    windowManager.updateTitle(win.id, resolved)
+    recordRecentRoot(resolved)
+    return resolved
   }
 
   return getWelcomeFolderPath()
@@ -626,17 +767,11 @@ ipcMain.handle('set-last-folder', async (event, folderPath: string) => {
   const stateId = windowManager.getWindowStateId(win.id)
   if (!stateId) return false
 
-  const settings = store.store
-  const openWindows = settings.openWindows || []
-  const index = openWindows.findIndex((w) => w.id === stateId)
+  const openWindows = store.store.openWindows || []
+  store.set('openWindows', setWindowFolder(openWindows, stateId, folderPath, DEFAULT_WINDOW_BOUNDS))
+  windowManager.updateTitle(win.id, folderPath)
+  recordRecentRoot(folderPath)
 
-  if (index >= 0) {
-    openWindows[index].lastFolder = folderPath
-    store.set('openWindows', openWindows)
-    windowManager.updateTitle(win.id, folderPath)
-  }
-
-  // Also update global for legacy/fallback? Maybe not needed.
   return true
 })
 
@@ -761,26 +896,30 @@ ipcMain.handle(
     const stateId = windowManager.getWindowStateId(win.id)
     if (!stateId) return false
 
-    const settings = store.store
-    const openWindows = settings.openWindows || []
-    const index = openWindows.findIndex((w) => w.id === stateId)
+    const normalizedPanes: PaneLayoutSettings[] = panes.map((pane) => ({
+      id: pane.id || randomUUID(),
+      tabs: pane.tabs || [],
+      activeTab: pane.activeTab ?? null,
+    }))
+    const normalizedRows: PaneRowLayout[] = rows.map((row) => ({
+      id: row.id || randomUUID(),
+      paneIds: row.paneIds || [],
+      size: row.size,
+      paneSizes: row.paneSizes,
+    }))
 
-    if (index >= 0) {
-      openWindows[index].paneLayout = panes.map((pane) => ({
-        id: pane.id || randomUUID(),
-        tabs: pane.tabs || [],
-        activeTab: pane.activeTab ?? null,
-      }))
-      openWindows[index].paneRows = rows.map((row) => ({
-        id: row.id || randomUUID(),
-        paneIds: row.paneIds || [],
-        size: row.size,
-        paneSizes: row.paneSizes,
-      }))
-      openWindows[index].activePaneId = activePaneId || undefined
-
-      store.set('openWindows', openWindows)
-    }
+    const openWindows = store.store.openWindows || []
+    store.set(
+      'openWindows',
+      setWindowPaneLayout(
+        openWindows,
+        stateId,
+        normalizedPanes,
+        normalizedRows,
+        activePaneId || undefined,
+        DEFAULT_WINDOW_BOUNDS
+      )
+    )
     return true
   }
 )
@@ -1422,9 +1561,13 @@ if (!gotTheLock) {
     // Extract paths from CLI arguments (handles both files and folders)
     const cliPaths = extractPathsFromArgv(argv)
 
-    if (cliPaths.files.length > 0 || cliPaths.folder) {
-      // CLI invocation with paths
+    if (cliPaths.folder) {
+      // When the CLI explicitly names a folder, honour it: set the workspace
+      // on the active window (legacy behaviour) and route the accompanying
+      // files through the normal logic.
       openCliPaths(cliPaths)
+    } else if (cliPaths.files.length > 0) {
+      openFilesViaRouter(cliPaths.files)
     } else {
       // No paths, just focus the existing window
       const windows = windowManager.getAllWindows()
@@ -1436,12 +1579,19 @@ if (!gotTheLock) {
     }
   })
 
-  // macOS: Handle file open via Finder (double-click, drag-drop, Open With)
+  // macOS: Handle file open via Finder (double-click, drag-drop, Open With).
+  // On a cold start this event fires before whenReady, so we queue the file
+  // and dispatch it once the app is ready (and any restored windows exist).
+  const pendingOpenFiles: string[] = []
+  let appIsReady = false
   app.on('open-file', (event, filePath) => {
     event.preventDefault()
-    if (filePath.endsWith('.lex')) {
-      openFilesInWindow([filePath])
+    if (!filePath.endsWith('.lex')) return
+    if (!appIsReady) {
+      pendingOpenFiles.push(filePath)
+      return
     }
+    openFilesViaRouter([filePath])
   })
 
   app.whenReady().then(async () => {
@@ -1530,15 +1680,24 @@ if (!gotTheLock) {
       // CLI invocation with paths
       if (cliPaths.folder) {
         store.set('lastFolder', cliPaths.folder)
+        recordRecentRoot(cliPaths.folder)
       }
       windowManager.createWindow(undefined, { showSplash: true, openFiles: cliPaths.files })
     } else if (welcomeFilePath) {
       // First launch: set the LexEd folder as workspace and open welcome file
       const projectPath = getDefaultProjectPath()
       store.set('lastFolder', projectPath)
+      recordRecentRoot(projectPath)
       windowManager.createWindow(undefined, { showSplash: true, openFiles: [welcomeFilePath] })
     } else {
       windowManager.restoreWindows()
+    }
+
+    // Dispatch any OS `open-file` events that arrived before we were ready.
+    appIsReady = true
+    if (pendingOpenFiles.length > 0) {
+      const queued = pendingOpenFiles.splice(0, pendingOpenFiles.length)
+      openFilesViaRouter(queued)
     }
   })
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -70,10 +70,14 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
       content: string
     }>,
   testRouteOpenFiles: (filePaths: string[]) =>
-    ipcRenderer.invoke('test-route-open-files', filePaths) as Promise<{
-      existingWindowIds: number[]
-      newWindowIds: number[]
-    }>,
+    ipcRenderer.invoke('test-route-open-files', filePaths) as Promise<
+      Array<{
+        filePath: string
+        kind: 'existingWindow' | 'newWindowWithRoot' | 'newWindow'
+        windowId: number
+        root?: string
+      }>
+    >,
   getNativeTheme: () => ipcRenderer.invoke('get-native-theme'),
   onNativeThemeChanged: (callback: (theme: 'dark' | 'light') => void) => {
     const handler = (_event: IpcRendererEvent, theme: 'dark' | 'light') => callback(theme)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -69,6 +69,11 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
       path: string
       content: string
     }>,
+  testRouteOpenFiles: (filePaths: string[]) =>
+    ipcRenderer.invoke('test-route-open-files', filePaths) as Promise<{
+      existingWindowIds: number[]
+      newWindowIds: number[]
+    }>,
   getNativeTheme: () => ipcRenderer.invoke('get-native-theme'),
   onNativeThemeChanged: (callback: (theme: 'dark' | 'light') => void) => {
     const handler = (_event: IpcRendererEvent, theme: 'dark' | 'light') => callback(theme)

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -106,9 +106,21 @@ const DEFAULT_WINDOW_STATE = {
   height: 800,
 }
 
+// Cap the number of windows we restore on launch. Entries accumulate in the
+// store under quit/crash paths that don't remove them; without a cap, a
+// machine that's been used long enough can spawn dozens of windows on every
+// launch. Keep the most-recently-appended entries (tail = more recent).
+const MAX_RESTORED_WINDOWS = 10
+
+interface WindowEntry {
+  window: BrowserWindow
+  lsp: LspManager
+  stateId: string
+  lastFocusedAt: number
+}
+
 export class WindowManager {
-  private windows: Map<number, { window: BrowserWindow; lsp: LspManager; stateId: string }> =
-    new Map()
+  private windows: Map<number, WindowEntry> = new Map()
   private store: Store<AppSettings>
   private isQuitting = false
   private splashWindow: BrowserWindow | null = null
@@ -212,6 +224,10 @@ export class WindowManager {
     return this.windows.get(id)?.stateId
   }
 
+  public getLastFocusedAt(id: number) {
+    return this.windows.get(id)?.lastFocusedAt ?? 0
+  }
+
   public getAllWindows() {
     return Array.from(this.windows.values()).map((w) => w.window)
   }
@@ -272,7 +288,15 @@ export class WindowManager {
       lsp.setWebContents(win.webContents)
       lsp.start()
 
-      this.windows.set(win.id, { window: win, lsp, stateId })
+      const entry: WindowEntry = { window: win, lsp, stateId, lastFocusedAt: Date.now() }
+      this.windows.set(win.id, entry)
+
+      // Track most-recent focus so the router's tiebreaker (recency) has data
+      // even when the app is backgrounded and no window is currently focused.
+      win.on('focus', () => {
+        const current = this.windows.get(win.id)
+        if (current) current.lastFocusedAt = Date.now()
+      })
 
       win.once('ready-to-show', () => {
         // Close splash and show main window
@@ -377,7 +401,14 @@ export class WindowManager {
     }
 
     const settings = this.store.store
-    const openWindows = settings.openWindows || []
+    let openWindows = settings.openWindows || []
+
+    // Trim accumulated state so a bloated store doesn't spawn dozens of
+    // windows on launch. Keeps the tail (most recently appended).
+    if (openWindows.length > MAX_RESTORED_WINDOWS) {
+      openWindows = openWindows.slice(-MAX_RESTORED_WINDOWS)
+      this.store.set('openWindows', openWindows)
+    }
 
     if (openWindows.length === 0) {
       this.createWindow(undefined, { showSplash: true })

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 import { randomUUID } from 'crypto'
 import { LspManager } from './lsp-manager'
 import Store from 'electron-store'
+import { mergeBounds } from './window-state'
 
 const SPLASH_SIZE = 256
 
@@ -76,8 +77,14 @@ export interface KeybindingSettings {
   overrides?: Record<string, KeybindingOverride>
 }
 
+export interface RecentRootEntry {
+  path: string
+  lastUsedAt: number
+}
+
 export interface AppSettings {
   openWindows?: WindowState[]
+  recentRoots?: RecentRootEntry[]
   // Global settings
   editor?: EditorSettings
   formatter?: FormatterSettings
@@ -331,32 +338,18 @@ export class WindowManager {
     const bounds = window.getBounds()
     const isMaximized = window.isMaximized()
 
-    // We need to fetch the current pane layout from the renderer or rely on what's been pushed to store
-    // For now, we assume the store is the source of truth for pane layout, updated via IPC
-    // But wait, the store is global. We need to update the specific window entry in the store.
-
     const currentSettings = this.store.store
     const openWindows = currentSettings.openWindows || []
-    const existingIndex = openWindows.findIndex((w) => w.id === stateId)
 
-    const newState: WindowState = {
-      id: stateId,
-      x: isMaximized ? undefined : bounds.x,
-      y: isMaximized ? undefined : bounds.y,
+    const updated = mergeBounds(openWindows, stateId, {
+      x: bounds.x,
+      y: bounds.y,
       width: isMaximized ? DEFAULT_WINDOW_STATE.width : bounds.width,
       height: isMaximized ? DEFAULT_WINDOW_STATE.height : bounds.height,
       isMaximized,
-      // Preserve existing state if present
-      ...(existingIndex >= 0 ? openWindows[existingIndex] : {}),
-    }
+    })
 
-    if (existingIndex >= 0) {
-      openWindows[existingIndex] = { ...openWindows[existingIndex], ...newState }
-    } else {
-      openWindows.push(newState)
-    }
-
-    this.store.set('openWindows', openWindows)
+    this.store.set('openWindows', updated)
   }
 
   public removeWindowState(stateId: string) {

--- a/electron/window-state.test.ts
+++ b/electron/window-state.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import {
+  upsertWindowState,
+  mergeBounds,
+  setWindowFolder,
+  setWindowPaneLayout,
+} from './window-state'
+import type { WindowState } from './window-manager'
+
+const defaultBounds = { width: 1200, height: 800 }
+
+describe('upsertWindowState', () => {
+  it('creates a new entry when stateId is missing', () => {
+    const result = upsertWindowState(
+      [],
+      'abc',
+      { lastFolder: '/docs' },
+      { width: 1200, height: 800 }
+    )
+    expect(result).toEqual([{ id: 'abc', width: 1200, height: 800, lastFolder: '/docs' }])
+  })
+
+  it('patches an existing entry without dropping other fields', () => {
+    const existing: WindowState[] = [
+      {
+        id: 'abc',
+        x: 100,
+        y: 50,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        lastFolder: '/old',
+      },
+    ]
+    const result = upsertWindowState(
+      existing,
+      'abc',
+      { lastFolder: '/new' },
+      { width: 1200, height: 800 }
+    )
+    expect(result).toEqual([
+      {
+        id: 'abc',
+        x: 100,
+        y: 50,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        lastFolder: '/new',
+      },
+    ])
+  })
+
+  it('does not mutate the input array', () => {
+    const existing: WindowState[] = [{ id: 'abc', width: 800, height: 600 }]
+    upsertWindowState(existing, 'xyz', { lastFolder: '/x' }, { width: 1200, height: 800 })
+    expect(existing).toHaveLength(1)
+  })
+})
+
+describe('mergeBounds', () => {
+  it('updates bounds on existing entry while preserving lastFolder', () => {
+    const existing: WindowState[] = [
+      {
+        id: 'abc',
+        x: 10,
+        y: 20,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        lastFolder: '/docs',
+      },
+    ]
+    const result = mergeBounds(existing, 'abc', {
+      x: 200,
+      y: 100,
+      width: 1400,
+      height: 900,
+      isMaximized: false,
+    })
+    expect(result[0]).toEqual({
+      id: 'abc',
+      x: 200,
+      y: 100,
+      width: 1400,
+      height: 900,
+      isMaximized: false,
+      lastFolder: '/docs',
+    })
+  })
+
+  it('clears x/y when maximized', () => {
+    const existing: WindowState[] = [
+      {
+        id: 'abc',
+        x: 10,
+        y: 20,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        lastFolder: '/docs',
+      },
+    ]
+    const result = mergeBounds(existing, 'abc', {
+      x: 200,
+      y: 100,
+      width: 1400,
+      height: 900,
+      isMaximized: true,
+    })
+    expect(result[0].x).toBeUndefined()
+    expect(result[0].y).toBeUndefined()
+    expect(result[0].isMaximized).toBe(true)
+    expect(result[0].lastFolder).toBe('/docs')
+  })
+
+  it('creates a new entry if stateId is not present', () => {
+    const result = mergeBounds([], 'abc', {
+      x: 200,
+      y: 100,
+      width: 1400,
+      height: 900,
+      isMaximized: false,
+    })
+    expect(result).toEqual([
+      {
+        id: 'abc',
+        x: 200,
+        y: 100,
+        width: 1400,
+        height: 900,
+        isMaximized: false,
+      },
+    ])
+  })
+})
+
+describe('setWindowFolder', () => {
+  it('persists folder on a brand-new window (the bug we are fixing)', () => {
+    const result = setWindowFolder([], 'abc', '/docs', defaultBounds)
+    expect(result).toEqual([{ id: 'abc', width: 1200, height: 800, lastFolder: '/docs' }])
+  })
+
+  it('updates folder on an existing window', () => {
+    const existing: WindowState[] = [{ id: 'abc', width: 800, height: 600, lastFolder: '/old' }]
+    const result = setWindowFolder(existing, 'abc', '/new', defaultBounds)
+    expect(result[0].lastFolder).toBe('/new')
+    expect(result[0].width).toBe(800)
+  })
+
+  it('does not touch unrelated entries', () => {
+    const existing: WindowState[] = [
+      { id: 'abc', width: 800, height: 600, lastFolder: '/a' },
+      { id: 'xyz', width: 1200, height: 800, lastFolder: '/b' },
+    ]
+    const result = setWindowFolder(existing, 'abc', '/new', defaultBounds)
+    expect(result[1]).toEqual(existing[1])
+  })
+})
+
+describe('setWindowPaneLayout', () => {
+  it('persists pane layout on a brand-new window', () => {
+    const result = setWindowPaneLayout(
+      [],
+      'abc',
+      [{ id: 'pane1', tabs: ['/a.lex'], activeTab: '/a.lex' }],
+      [{ id: 'row1', paneIds: ['pane1'] }],
+      'pane1',
+      defaultBounds
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].paneLayout).toHaveLength(1)
+    expect(result[0].activePaneId).toBe('pane1')
+  })
+
+  it('overwrites prior pane layout but preserves lastFolder', () => {
+    const existing: WindowState[] = [
+      {
+        id: 'abc',
+        width: 800,
+        height: 600,
+        lastFolder: '/docs',
+        paneLayout: [{ id: 'old', tabs: [] }],
+        paneRows: [],
+        activePaneId: 'old',
+      },
+    ]
+    const result = setWindowPaneLayout(
+      existing,
+      'abc',
+      [{ id: 'new', tabs: ['/a.lex'], activeTab: '/a.lex' }],
+      [{ id: 'row1', paneIds: ['new'] }],
+      'new',
+      defaultBounds
+    )
+    expect(result[0].lastFolder).toBe('/docs')
+    expect(result[0].paneLayout?.[0].id).toBe('new')
+    expect(result[0].activePaneId).toBe('new')
+  })
+})

--- a/electron/window-state.ts
+++ b/electron/window-state.ts
@@ -1,0 +1,108 @@
+import type { PaneLayoutSettings, PaneRowLayout, WindowState } from './window-manager'
+
+/**
+ * Return a new openWindows list with the entry for `stateId` upserted:
+ * if it exists, shallow-merge the patch onto it; otherwise push a new entry
+ * built from `fallback`.
+ *
+ * The previous implementation used `findIndex(...) >= 0` and silently dropped
+ * writes for brand-new windows that had not yet gone through saveWindowState.
+ * That meant the workspace root was never persisted until close, and even
+ * then only if some earlier write had already created the entry.
+ */
+export function upsertWindowState(
+  openWindows: WindowState[],
+  stateId: string,
+  patch: Partial<WindowState>,
+  fallback: Omit<WindowState, 'id'>
+): WindowState[] {
+  const next = openWindows.slice()
+  const index = next.findIndex((w) => w.id === stateId)
+  if (index >= 0) {
+    next[index] = { ...next[index], ...patch, id: stateId }
+  } else {
+    next.push({ ...fallback, ...patch, id: stateId })
+  }
+  return next
+}
+
+export interface BoundsPatch {
+  x?: number
+  y?: number
+  width: number
+  height: number
+  isMaximized: boolean
+}
+
+/**
+ * Merge fresh window bounds into the openWindows list without clobbering
+ * previously-persisted per-window state (lastFolder, paneLayout, ...).
+ *
+ * This replaces the buggy saveWindowState logic where the spread order was
+ * reversed, so stale bounds overwrote fresh ones and window geometry never
+ * updated across launches.
+ */
+export function mergeBounds(
+  openWindows: WindowState[],
+  stateId: string,
+  bounds: BoundsPatch
+): WindowState[] {
+  return upsertWindowState(
+    openWindows,
+    stateId,
+    {
+      x: bounds.isMaximized ? undefined : bounds.x,
+      y: bounds.isMaximized ? undefined : bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      isMaximized: bounds.isMaximized,
+    },
+    {
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      isMaximized: bounds.isMaximized,
+    }
+  )
+}
+
+export function setWindowFolder(
+  openWindows: WindowState[],
+  stateId: string,
+  folderPath: string,
+  defaultBounds: { width: number; height: number }
+): WindowState[] {
+  return upsertWindowState(
+    openWindows,
+    stateId,
+    { lastFolder: folderPath },
+    {
+      width: defaultBounds.width,
+      height: defaultBounds.height,
+      lastFolder: folderPath,
+    }
+  )
+}
+
+export function setWindowPaneLayout(
+  openWindows: WindowState[],
+  stateId: string,
+  paneLayout: PaneLayoutSettings[],
+  paneRows: PaneRowLayout[],
+  activePaneId: string | undefined,
+  defaultBounds: { width: number; height: number }
+): WindowState[] {
+  return upsertWindowState(
+    openWindows,
+    stateId,
+    { paneLayout, paneRows, activePaneId },
+    {
+      width: defaultBounds.width,
+      height: defaultBounds.height,
+      paneLayout,
+      paneRows,
+      activePaneId,
+    }
+  )
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -20,9 +20,14 @@ interface Window {
     getInitialFolder: () => Promise<string>
     setLastFolder: (folderPath: string) => Promise<boolean>
     loadTestFixture: (fixtureName: string) => Promise<{ path: string; content: string }>
-    testRouteOpenFiles: (
-      filePaths: string[]
-    ) => Promise<{ existingWindowIds: number[]; newWindowIds: number[] }>
+    testRouteOpenFiles: (filePaths: string[]) => Promise<
+      Array<{
+        filePath: string
+        kind: 'existingWindow' | 'newWindowWithRoot' | 'newWindow'
+        windowId: number
+        root?: string
+      }>
+    >
     getNativeTheme: () => Promise<'dark' | 'light'>
     onNativeThemeChanged: (callback: (theme: 'dark' | 'light') => void) => () => void
     getOpenTabs: () => Promise<{

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -20,6 +20,9 @@ interface Window {
     getInitialFolder: () => Promise<string>
     setLastFolder: (folderPath: string) => Promise<boolean>
     loadTestFixture: (fixtureName: string) => Promise<{ path: string; content: string }>
+    testRouteOpenFiles: (
+      filePaths: string[]
+    ) => Promise<{ existingWindowIds: number[]; newWindowIds: number[] }>
     getNativeTheme: () => Promise<'dark' | 'light'>
     onNativeThemeChanged: (callback: (theme: 'dark' | 'light') => void) => () => void
     getOpenTabs: () => Promise<{

--- a/tests/e2e/file-routing.spec.ts
+++ b/tests/e2e/file-routing.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { launchApp } from './helpers'
+
+/**
+ * These tests exercise the groundwork for OS-level file opens:
+ *   1. Per-window workspace root persistence (regression against the old
+ *      `set-last-folder` bug that silently dropped writes for new windows).
+ *   2. The `recentRoots` history written to the store on folder changes.
+ *   3. The main-process router that decides where an OS-opened file lands
+ *      (invoked via a test-only IPC that mirrors the macOS `open-file`
+ *      event and the Windows/Linux `second-instance` argv path).
+ *
+ * Each test uses its own `--user-data-dir` so electron-store writes never
+ * leak into the user's real settings. `LEX_DISABLE_PERSISTENCE=0` is
+ * required: the default fixture forces it to `1`, which short-circuits the
+ * very persistence we're trying to verify here.
+ */
+
+type LaunchHandle = {
+  app: ElectronApplication
+  page: Page
+}
+
+async function launchReady(userData: string): Promise<LaunchHandle> {
+  const app = await launchApp({
+    env: { LEX_DISABLE_PERSISTENCE: '0' },
+    extraArgs: [`--user-data-dir=${userData}`],
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForFunction(() => Boolean((window as Window).lexTest), null, {
+    timeout: 15000,
+  })
+  return { app, page }
+}
+
+async function setWorkspace(page: Page, folderPath: string): Promise<void> {
+  await page.evaluate(async (dir) => {
+    await window.lexTest!.openFolder!(dir)
+  }, folderPath)
+  // Give the setLastFolder IPC round-trip a tick to complete.
+  await page.waitForFunction(
+    (expected) => (window as Window).__lexWorkspaceRoot === expected,
+    folderPath,
+    { timeout: 5000 }
+  )
+}
+
+function mkTmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function rmrf(dir: string) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true })
+  } catch {
+    // ignore
+  }
+}
+
+test.describe('File routing & workspace persistence', () => {
+  let userData: string
+
+  test.beforeEach(() => {
+    userData = mkTmp('lexed-userdata-')
+  })
+
+  test.afterEach(() => {
+    rmrf(userData)
+  })
+
+  test('persists the window workspace root across relaunches', async () => {
+    const workspace = mkTmp('lexed-ws-')
+    try {
+      fs.writeFileSync(path.join(workspace, 'hello.lex'), 'hello')
+
+      // Launch 1 — set a root.
+      {
+        const { app, page } = await launchReady(userData)
+        await setWorkspace(page, workspace)
+        const settings = await page.evaluate(() => window.ipcRenderer.getAppSettings())
+        const entry = settings.openWindows?.[0]
+        expect(entry?.lastFolder).toBe(workspace)
+        await app.close()
+      }
+
+      // Launch 2 — expect the same root to come back.
+      {
+        const { app, page } = await launchReady(userData)
+        const restoredRoot = await page.waitForFunction(
+          () => (window as Window).__lexWorkspaceRoot,
+          null,
+          { timeout: 5000 }
+        )
+        expect(await restoredRoot.jsonValue()).toBe(workspace)
+        await app.close()
+      }
+    } finally {
+      rmrf(workspace)
+    }
+  })
+
+  test('records every workspace change in recentRoots (most recent first)', async () => {
+    const workspaceA = mkTmp('lexed-wsA-')
+    const workspaceB = mkTmp('lexed-wsB-')
+    try {
+      const { app, page } = await launchReady(userData)
+      await setWorkspace(page, workspaceA)
+      await setWorkspace(page, workspaceB)
+
+      const settings = await page.evaluate(() => window.ipcRenderer.getAppSettings())
+      const paths: string[] = (settings.recentRoots ?? []).map((r: { path: string }) => r.path)
+      expect(paths).toContain(workspaceA)
+      expect(paths).toContain(workspaceB)
+      expect(paths[0]).toBe(workspaceB)
+
+      await app.close()
+    } finally {
+      rmrf(workspaceA)
+      rmrf(workspaceB)
+    }
+  })
+
+  test('OS-opens a file under the current workspace root into the same window', async () => {
+    const workspace = mkTmp('lexed-ws-')
+    try {
+      const filePath = path.join(workspace, 'a.lex')
+      fs.writeFileSync(filePath, 'content')
+
+      const { app, page } = await launchReady(userData)
+      await setWorkspace(page, workspace)
+
+      const result = await page.evaluate(async (fp) => {
+        return window.ipcRenderer.testRouteOpenFiles([fp])
+      }, filePath)
+
+      expect(result.newWindowIds).toEqual([])
+      expect(result.existingWindowIds.length).toBeGreaterThan(0)
+
+      await expect(page.locator(`[data-tab-path="${filePath}"]`)).toBeVisible({
+        timeout: 5000,
+      })
+
+      await app.close()
+    } finally {
+      rmrf(workspace)
+    }
+  })
+
+  test('OS-opens a file under a recent (non-current) root in a new window with that root', async () => {
+    const workspaceA = mkTmp('lexed-wsA-')
+    const workspaceB = mkTmp('lexed-wsB-')
+    try {
+      const fileInA = path.join(workspaceA, 'a.lex')
+      fs.writeFileSync(fileInA, 'content')
+
+      const { app, page } = await launchReady(userData)
+      await setWorkspace(page, workspaceA)
+      await setWorkspace(page, workspaceB)
+      // Current window's root is now B; A is in recentRoots but not open.
+
+      const result = await page.evaluate(async (fp) => {
+        return window.ipcRenderer.testRouteOpenFiles([fp])
+      }, fileInA)
+
+      expect(result.newWindowIds).toHaveLength(1)
+
+      await app.close()
+    } finally {
+      rmrf(workspaceA)
+      rmrf(workspaceB)
+    }
+  })
+})

--- a/tests/e2e/file-routing.spec.ts
+++ b/tests/e2e/file-routing.spec.ts
@@ -138,12 +138,15 @@ test.describe('File routing & workspace persistence', () => {
         return window.ipcRenderer.testRouteOpenFiles([fp])
       }, filePath)
 
-      expect(result.newWindowIds).toEqual([])
-      expect(result.existingWindowIds.length).toBeGreaterThan(0)
+      expect(result).toHaveLength(1)
+      expect(result[0].kind).toBe('existingWindow')
+      expect(result[0].filePath).toBe(filePath)
 
-      await expect(page.locator(`[data-tab-path="${filePath}"]`)).toBeVisible({
-        timeout: 5000,
-      })
+      // Locator by testid + basename text — portable across platforms where
+      // the absolute path may contain backslashes or get normalized.
+      await expect(
+        page.locator('[data-testid="editor-tab"]').filter({ hasText: path.basename(filePath) })
+      ).toBeVisible({ timeout: 5000 })
 
       await app.close()
     } finally {
@@ -163,11 +166,29 @@ test.describe('File routing & workspace persistence', () => {
       await setWorkspace(page, workspaceB)
       // Current window's root is now B; A is in recentRoots but not open.
 
+      const newWindowPromise = app.waitForEvent('window')
       const result = await page.evaluate(async (fp) => {
         return window.ipcRenderer.testRouteOpenFiles([fp])
       }, fileInA)
 
-      expect(result.newWindowIds).toHaveLength(1)
+      expect(result).toHaveLength(1)
+      expect(result[0].kind).toBe('newWindowWithRoot')
+      expect(result[0].root).toBe(workspaceA)
+
+      const newPage = await newWindowPromise
+      await newPage.waitForLoadState('domcontentloaded')
+      await newPage.waitForFunction(() => Boolean((window as Window).lexTest), null, {
+        timeout: 15000,
+      })
+      await newPage.waitForFunction(
+        (expected) => (window as Window).__lexWorkspaceRoot === expected,
+        workspaceA,
+        { timeout: 5000 }
+      )
+
+      await expect(
+        newPage.locator('[data-testid="editor-tab"]').filter({ hasText: path.basename(fileInA) })
+      ).toBeVisible({ timeout: 10000 })
 
       await app.close()
     } finally {


### PR DESCRIPTION
## Summary

When Finder (macOS) or `lexed <path>` (Windows/Linux) hands a `.lex` file to an already-running LexEd, the file always went to `windows[0]`. If that window's workspace root didn't contain the file, the handler ran but the file was effectively invisible in the wrong workspace — the reported "silently does not open at all" behavior.

This PR routes each OS-opened file to the most appropriate window:

1. An open window whose workspace root contains the file (longest-match wins; ties broken by focus / recency).
2. Otherwise, a new window seeded with a matching recent root.
3. Otherwise, the focused (or most-recently-focused) open window.
4. Otherwise, a new window with no workspace root.

Fixing the routing turned up two prerequisite persistence bugs that had to be addressed first:

- **`set-last-folder` silently dropped writes for new windows.** The IPC only updated an entry that already existed, and new windows had no entry until `saveWindowState` ran on close. So a brand-new window's workspace root never persisted. Same pattern fixed in `set-open-tabs`.
- **`saveWindowState` had its spread order reversed**, so fresh bounds were overwritten by stale ones and window geometry never updated across launches.

Also: dev-mode argv parsing used to misread the Electron bootstrap arg (`electron .`) as a user-supplied workspace folder, setting the repo root as `lastFolder` on every dev launch.

## Design

- **Pure logic in `electron/file-routing.ts`** (`isPathInsideRoot`, `findBestRoot`, `routeOpenFile`, `updateRecentRoots`) — platform-aware case sensitivity, 38 unit tests.
- **Pure persistence helpers in `electron/window-state.ts`** (`upsertWindowState`, `mergeBounds`, `setWindowFolder`, `setWindowPaneLayout`) — 11 unit tests.
- **Thin wiring in `main.ts`**: `openFilesViaRouter` replaces the `windows[0]` shortcut, groups files per destination, and is called from both `app.on('open-file')` (macOS, with a pre-`whenReady` queue for cold-start Finder opens) and `app.on('second-instance')` (Win/Linux CLI).
- **New `recentRoots` slice** in `AppSettings` + store schema, populated on every folder change (explicit open, initial-folder restore, CLI argument, first-launch welcome path). Capped at 20, deduped case-appropriately per-platform.

## Test plan

- [x] `npm run test:unit` — 77 passed (38 for file-routing, 11 for window-state, rest pre-existing).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run test:e2e:built` — 36 passed, 1 skipped (packaged). The pre-commit hook runs the built e2e suite.
- [x] New e2e spec `tests/e2e/file-routing.spec.ts`:
  - workspace root persists across app relaunch
  - `recentRoots` grows on every folder change, most-recent-first
  - OS-opened file under current root lands as a tab in the current window
  - OS-opened file under a recent (non-current) root opens a new window with that root

## Not in scope

Per-workspace `.lexed.toml` config files were discussed but deferred — would still need a global recent-roots list for OS-open routing, and adds unrelated scope (migration, gitignore guidance, workspace-moved/deleted handling). Can land later independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)