### PR TITLE
Adopt @lex/shared/injections + Monaco host adapter (#24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download tree-sitter grammar
+        run: bash scripts/download-tree-sitter.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build renderer and main process
         run: npm run icons && npx tsc && npx vite build
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ node_modules
 /resources/lexd-lsp
 /resources/lexd-lsp.exe
 
+# Downloaded tree-sitter grammar + queries
+# (fetched by scripts/download-tree-sitter.sh)
+/resources/tree-sitter-lex.wasm
+/resources/queries/
+
 # Logs
 logs
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-ws-jsonrpc": "^3.5.0"
+        "vscode-ws-jsonrpc": "^3.5.0",
+        "web-tree-sitter": "^0.25.10"
       },
       "devDependencies": {
         "@cspell/cspell-tools": "^10.0.0",
@@ -58,6 +59,9 @@
         "vite-plugin-electron": "^0.28.6",
         "vite-plugin-electron-renderer": "^0.14.5",
         "vitest": "^4.0.15"
+      },
+      "engines": {
+        "node": ">=22.18"
       }
     },
     "../shared": {
@@ -11159,6 +11163,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
     "node": ">=22.18"
   },
   "scripts": {
-    "predev": "bash scripts/fetch-deps.sh --if-missing",
+    "predev": "bash scripts/fetch-deps.sh --if-missing && bash scripts/download-tree-sitter.sh --if-missing",
     "dev": "vite",
     "dev:local": "vite",
     "icons": "node ./scripts/generate-icons.mjs",
     "prebuild": "npm run icons && npm run build:quicklook",
     "build:quicklook": "bash ./scripts/build-quicklook.sh",
-    "build": "bash scripts/fetch-deps.sh --if-missing && tsc && vite build && electron-builder",
+    "build": "bash scripts/fetch-deps.sh --if-missing && bash scripts/download-tree-sitter.sh --if-missing && tsc && vite build && electron-builder",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0",
     "format": "prettier --write 'src/**/*.{ts,tsx}' 'electron/**/*.ts' 'tests/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx}' 'electron/**/*.ts' 'tests/**/*.ts'",
     "preview": "vite preview",
-    "pretest:e2e": "npm run icons",
+    "pretest:e2e": "npm run icons && bash scripts/download-tree-sitter.sh --if-missing",
     "test:e2e": "LEX_HIDE_WINDOW=1 PLAYWRIGHT_BROWSERS_PATH=0 LEX_DISABLE_PERSISTENCE=1 npx playwright test tests/e2e",
     "test:e2e:dev": "LEX_SKIP_E2E_BUILD=1 LEX_DISABLE_PERSISTENCE=1 npx playwright test tests/e2e",
     "test:e2e:built": "LEX_E2E_USE_BUILD=1 LEX_SKIP_E2E_BUILD=1 LEX_HIDE_WINDOW=1 PLAYWRIGHT_BROWSERS_PATH=0 LEX_DISABLE_PERSISTENCE=1 npx playwright test tests/e2e",
@@ -60,7 +60,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "vscode-languageserver-protocol": "^3.17.5",
-    "vscode-ws-jsonrpc": "^3.5.0"
+    "vscode-ws-jsonrpc": "^3.5.0",
+    "web-tree-sitter": "^0.25.10"
   },
   "devDependencies": {
     "@cspell/cspell-tools": "^10.0.0",

--- a/scripts/download-tree-sitter.sh
+++ b/scripts/download-tree-sitter.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads tree-sitter artifact (lex grammar WASM + queries) from GitHub releases.
+# The web-tree-sitter runtime WASM is copied out of node_modules at build time
+# (see scripts/copy-tree-sitter-runtime.mjs).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOURCES_DIR="$APP_DIR/resources"
+
+IF_MISSING=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --if-missing) IF_MISSING=true; shift ;;
+    -h|--help)
+      echo "Usage: $(basename "$0") [--if-missing]"
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+TS_VERSION="$(node "$SCRIPT_DIR/read-lex-config.mjs" tree-sitter version)"
+TS_REPO="$(node "$SCRIPT_DIR/read-lex-config.mjs" tree-sitter repo)"
+
+download_tree_sitter() {
+  if $IF_MISSING && [[ -f "$RESOURCES_DIR/tree-sitter-lex.wasm" ]] && [[ -d "$RESOURCES_DIR/queries" ]]; then
+    echo "tree-sitter artifacts already present at $RESOURCES_DIR, skipping"
+    return 0
+  fi
+
+  echo "Downloading tree-sitter $TS_VERSION..."
+
+  local download_url="https://github.com/$TS_REPO/releases/download/$TS_VERSION/tree-sitter.tar.gz"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  local archive_path="$tmp_dir/tree-sitter.tar.gz"
+
+  local curl_opts=(-fsSL -o "$archive_path")
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl_opts+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+
+  if ! curl "${curl_opts[@]}" "$download_url"; then
+    echo "Failed to download $download_url" >&2
+    rm -rf "$tmp_dir"
+    exit 1
+  fi
+
+  mkdir -p "$tmp_dir/extracted"
+  tar -xzf "$archive_path" -C "$tmp_dir/extracted"
+
+  mkdir -p "$RESOURCES_DIR/queries"
+  cp "$tmp_dir/extracted/tree-sitter-lex.wasm" "$RESOURCES_DIR/tree-sitter-lex.wasm"
+  cp "$tmp_dir/extracted/queries/"*.scm "$RESOURCES_DIR/queries/"
+
+  rm -rf "$tmp_dir"
+  echo "tree-sitter $TS_VERSION → $RESOURCES_DIR"
+}
+
+mkdir -p "$RESOURCES_DIR"
+download_tree_sitter

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -200,6 +200,13 @@ else
 fi
 
 for dep in "${DEPS[@]}"; do
+  # tree-sitter is fetched via the dedicated download-tree-sitter.sh
+  # (non-platform archive), so skip it here when iterating the full
+  # dep list.
+  if [[ "$dep" == "tree-sitter" ]]; then
+    continue
+  fi
+
   binary_name="$dep"
   [[ "$TARGET_TRIPLE" == *windows* ]] && binary_name="${dep}.exe"
   dest="$RESOURCES_DIR/$binary_name"

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -3,6 +3,10 @@
     "lexd-lsp": {
       "version": "v0.8.5",
       "repo": "lex-fmt/lex"
+    },
+    "tree-sitter": {
+      "version": "v0.8.3",
+      "repo": "lex-fmt/tree-sitter-lex"
     }
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,4 +2,5 @@ export * from './constants.js';
 export * from './types.js';
 export * from './platform.js';
 export * as commands from './commands/index.js';
+export * as injections from './injections/index.js';
 

--- a/shared/src/injections/compute.ts
+++ b/shared/src/injections/compute.ts
@@ -1,0 +1,59 @@
+import { CATEGORY_COLORS } from './constants.js';
+import { mapTokensToDecorations } from './mapTokens.js';
+import { resolveLanguageId } from './resolve.js';
+import type {
+  DecorationCategory,
+  InjectionHostAdapter,
+  InjectionRange,
+  InjectionZone,
+} from './types.js';
+
+/**
+ * Orchestrator: given a parsed set of injection zones and a host adapter,
+ * returns the aggregated `InjectionRange`s per `DecorationCategory`.
+ *
+ * Behaviour contract:
+ *   - The registered-languages set is fetched once per call via the adapter.
+ *     Hosts are expected to cache this themselves across calls (the vscode
+ *     adapter caches for 30s so newly installed extensions are picked up).
+ *   - Zones whose language does not resolve to a registered ID are skipped.
+ *   - Zones whose `getSemanticTokens` call returns `null` are skipped.
+ *   - Zones whose `getSemanticTokens` throws are skipped — errors never
+ *     bubble out of this function.
+ *
+ * The returned map always contains an entry for every `DecorationCategory`
+ * (empty array when no tokens matched) so callers can iterate and apply the
+ * correct clear-plus-set sequence against their native decoration API.
+ */
+export async function computeInjectionDecorations(
+  zones: InjectionZone[],
+  host: InjectionHostAdapter,
+): Promise<Map<DecorationCategory, InjectionRange[]>> {
+  const rangesByCategory = new Map<DecorationCategory, InjectionRange[]>();
+  for (const category of Object.keys(CATEGORY_COLORS) as DecorationCategory[]) {
+    rangesByCategory.set(category, []);
+  }
+
+  if (zones.length === 0) return rangesByCategory;
+
+  const registered = await host.getRegisteredLanguages();
+
+  for (let i = 0; i < zones.length; i++) {
+    const zone = zones[i];
+    const langId = resolveLanguageId(zone.language, registered);
+    if (!langId) continue;
+
+    let tokens;
+    try {
+      tokens = await host.getSemanticTokens(i, zone.text, langId);
+    } catch {
+      // Provider errored — skip this zone (matches vscode behaviour)
+      continue;
+    }
+    if (!tokens) continue;
+
+    mapTokensToDecorations(tokens, zone, rangesByCategory);
+  }
+
+  return rangesByCategory;
+}

--- a/shared/src/injections/constants.ts
+++ b/shared/src/injections/constants.ts
@@ -1,0 +1,87 @@
+import type { DecorationCategory } from './types.js';
+
+/**
+ * Debounce window between document edits and the next highlight refresh.
+ * Lifted verbatim from the original vscode implementation.
+ */
+export const DEBOUNCE_MS = 250;
+
+/**
+ * URI scheme used for virtual documents that back semantic-token requests.
+ * Hosts register a text-document content provider against this scheme.
+ */
+export const VIRTUAL_DOC_SCHEME = 'lex-embedded';
+
+/**
+ * Common annotation aliases → host language IDs.
+ * If the annotation text is already a registered language ID, it's used
+ * directly (see `resolveLanguageId`).
+ */
+export const LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
+  py: 'python',
+  js: 'javascript',
+  jsx: 'javascriptreact',
+  ts: 'typescript',
+  tsx: 'typescriptreact',
+  rs: 'rust',
+  rb: 'ruby',
+  sh: 'shellscript',
+  bash: 'shellscript',
+  zsh: 'shellscript',
+  shell: 'shellscript',
+  yml: 'yaml',
+  'c++': 'cpp',
+  cxx: 'cpp',
+  cc: 'cpp',
+  htm: 'html',
+  golang: 'go',
+};
+
+/**
+ * Standard semantic token types → decoration categories. Types not listed
+ * here (variable, parameter, property, etc.) get no special coloring — they
+ * inherit the editor's default foreground.
+ */
+export const SEMANTIC_TOKEN_MAP: Readonly<Record<string, DecorationCategory>> = {
+  keyword: 'keyword',
+  modifier: 'keyword',
+  function: 'function',
+  method: 'function',
+  macro: 'function',
+  decorator: 'function',
+  string: 'string',
+  regexp: 'string',
+  number: 'number',
+  comment: 'comment',
+  type: 'type',
+  class: 'type',
+  enum: 'type',
+  interface: 'type',
+  struct: 'type',
+  typeParameter: 'type',
+  namespace: 'type',
+  operator: 'operator',
+};
+
+/**
+ * Theme color IDs per category. Hosts translate these into native decoration
+ * types (`vscode.ThemeColor` / monaco theme token, etc.).
+ */
+export const CATEGORY_COLORS: Readonly<Record<DecorationCategory, string>> = {
+  keyword: 'lex.injection.keyword',
+  string: 'lex.injection.string',
+  comment: 'lex.injection.comment',
+  number: 'lex.injection.number',
+  type: 'lex.injection.type',
+  function: 'lex.injection.function',
+  operator: 'lex.injection.operator',
+};
+
+/**
+ * Font-style overrides per category. Missing entries default to the editor's
+ * regular style.
+ */
+export const CATEGORY_STYLES: Readonly<Partial<Record<DecorationCategory, string>>> = {
+  comment: 'italic',
+  keyword: 'bold',
+};

--- a/shared/src/injections/index.ts
+++ b/shared/src/injections/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js';
+export * from './constants.js';
+export * from './resolve.js';
+export * from './mapTokens.js';
+export * from './compute.js';

--- a/shared/src/injections/mapTokens.ts
+++ b/shared/src/injections/mapTokens.ts
@@ -1,0 +1,70 @@
+import { SEMANTIC_TOKEN_MAP } from './constants.js';
+import type {
+  DecorationCategory,
+  InjectionRange,
+  InjectionZone,
+  SemanticTokens,
+} from './types.js';
+
+/**
+ * Walks a semantic-tokens payload produced against a zone's virtual
+ * document and appends the host-neutral `InjectionRange`s per category into
+ * `rangesByCategory`.
+ *
+ * The LSP semantic-tokens wire format encodes each token as five u32 deltas:
+ *   [deltaLine, deltaStart, length, typeIndex, modifierBitset]
+ *
+ * We decode the running (line, startChar) position and translate it from the
+ * virtual document (which contains only the zone text) back into coordinates
+ * of the real document. The first line of the zone is offset by
+ * `zone.startCol`; subsequent lines use raw `startChar`.
+ *
+ * Tokens whose type is unknown (`legend.tokenTypes[typeIndex]` missing) or
+ * not in `SEMANTIC_TOKEN_MAP` are silently skipped, matching the original
+ * vscode implementation.
+ */
+export function mapTokensToDecorations(
+  tokens: SemanticTokens,
+  zone: InjectionZone,
+  rangesByCategory: Map<DecorationCategory, InjectionRange[]>,
+): void {
+  const { legend, data } = tokens;
+  let line = 0;
+  let startChar = 0;
+
+  for (let i = 0; i < data.length; i += 5) {
+    const deltaLine = data[i];
+    const deltaStart = data[i + 1];
+    const length = data[i + 2];
+    const typeIndex = data[i + 3];
+
+    if (deltaLine > 0) {
+      line += deltaLine;
+      startChar = deltaStart;
+    } else {
+      startChar += deltaStart;
+    }
+
+    const tokenTypeName = legend.tokenTypes[typeIndex];
+    if (!tokenTypeName) continue;
+
+    const category = SEMANTIC_TOKEN_MAP[tokenTypeName];
+    if (!category) continue;
+
+    const ranges = rangesByCategory.get(category);
+    if (!ranges) continue;
+
+    // Virtual-doc position → real-doc position.
+    // Line 0 of the virtual doc starts at column `zone.startCol` in the
+    // real doc; subsequent lines start at column 0.
+    const realLine = zone.startRow + line;
+    const realStartChar = line === 0 ? zone.startCol + startChar : startChar;
+
+    ranges.push({
+      startLine: realLine,
+      startCol: realStartChar,
+      endLine: realLine,
+      endCol: realStartChar + length,
+    });
+  }
+}

--- a/shared/src/injections/resolve.ts
+++ b/shared/src/injections/resolve.ts
@@ -1,0 +1,18 @@
+import { LANGUAGE_ALIASES } from './constants.js';
+
+/**
+ * Resolves an annotation string (e.g. `"py"`, `" Python "`, `"rust"`) to a
+ * host language ID (e.g. `"python"`, `"rust"`), honouring aliases.
+ *
+ * Returns `null` if the resolved ID is not in `registeredLanguages` — this is
+ * the shared's way of saying "no provider will handle this zone, skip it".
+ */
+export function resolveLanguageId(
+  annotation: string,
+  registeredLanguages: Set<string>,
+): string | null {
+  const name = annotation.toLowerCase().trim();
+  if (!name) return null;
+  const resolved = LANGUAGE_ALIASES[name] ?? name;
+  return registeredLanguages.has(resolved) ? resolved : null;
+}

--- a/shared/src/injections/types.ts
+++ b/shared/src/injections/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Host-neutral types for the injection highlighter.
+ *
+ * The shared injection module maps semantic-token output (from whatever host
+ * syntax provider is available) onto the Lex document's verbatim zones. It
+ * avoids any direct dependency on vscode, monaco, or web-tree-sitter so that
+ * both `lex-vscode` and `lexed` can reuse the logic.
+ */
+
+export type DecorationCategory =
+  | 'keyword'
+  | 'string'
+  | 'comment'
+  | 'number'
+  | 'type'
+  | 'function'
+  | 'operator';
+
+/**
+ * Zero-based range in the real Lex document.
+ */
+export interface InjectionRange {
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+}
+
+/**
+ * A verbatim zone in the Lex document that has an annotated language.
+ *
+ * This matches the shape produced by `LexTreeSitter.queryInjections` — the
+ * type is lifted into `@lex/shared` so host adapters can pass zones in
+ * without importing vscode-specific modules.
+ */
+export interface InjectionZone {
+  language: string;
+  text: string;
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+}
+
+/**
+ * Minimal semantic-tokens payload: just the ordered `tokenTypes` legend and
+ * the raw deltas array as produced by VS Code's
+ * `vscode.provideDocumentSemanticTokens` command (or its equivalent).
+ */
+export interface SemanticTokens {
+  legend: { tokenTypes: readonly string[] };
+  data: Uint32Array;
+}
+
+/**
+ * Contract implemented by each editor host. The shared module only needs two
+ * operations:
+ *
+ * 1. `getRegisteredLanguages` — resolve which language IDs the host actually
+ *    knows how to tokenize. Hosts are expected to cache this themselves (the
+ *    vscode adapter caches for 30s; lexed will cache similarly).
+ * 2. `getSemanticTokens` — for a given zone's content and resolved language
+ *    id, ask the host for semantic tokens. Returning `null` signals that no
+ *    provider responded — the zone is skipped silently.
+ */
+export interface InjectionHostAdapter {
+  getRegisteredLanguages(): Promise<Set<string>>;
+  getSemanticTokens(
+    zoneIndex: number,
+    content: string,
+    langId: string,
+  ): Promise<SemanticTokens | null>;
+}

--- a/shared/test/injections/computeInjectionDecorations.test.ts
+++ b/shared/test/injections/computeInjectionDecorations.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { injections } from '@lex/shared';
+
+const { computeInjectionDecorations } = injections;
+type InjectionZone = injections.InjectionZone;
+type InjectionHostAdapter = injections.InjectionHostAdapter;
+type SemanticTokens = injections.SemanticTokens;
+
+function makeZone(lang: string, text: string, row: number, col: number): InjectionZone {
+  return {
+    language: lang,
+    text,
+    startRow: row,
+    startCol: col,
+    endRow: row + 3,
+    endCol: 0,
+  };
+}
+
+const KW_STR_LEGEND = { tokenTypes: ['keyword', 'string'] };
+
+function tokensPayload(data: Uint32Array): SemanticTokens {
+  return { legend: KW_STR_LEGEND, data };
+}
+
+describe('computeInjectionDecorations', () => {
+  it('aggregates ranges across multiple zones', async () => {
+    const zones = [
+      makeZone('python', 'def x: pass', 10, 2),
+      makeZone('javascript', 'const y = 1', 20, 0),
+    ];
+
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python', 'javascript'])),
+      getSemanticTokens: () => Promise.resolve(tokensPayload(new Uint32Array([0, 0, 3, 0, 0]))),
+    };
+
+    const ranges = await computeInjectionDecorations(zones, host);
+    const kw = ranges.get('keyword')!;
+    expect(kw).toHaveLength(2);
+    expect(kw[0]).toEqual({ startLine: 10, startCol: 2, endLine: 10, endCol: 5 });
+    expect(kw[1]).toEqual({ startLine: 20, startCol: 0, endLine: 20, endCol: 3 });
+
+    for (const category of ['string', 'comment', 'number', 'type', 'function', 'operator'] as const) {
+      expect(ranges.get(category)).toEqual([]);
+    }
+  });
+
+  it('unregistered language is skipped', async () => {
+    const zones = [makeZone('python', 'def x', 0, 0), makeZone('cobol', 'DISPLAY "X"', 5, 0)];
+    let calls = 0;
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python'])),
+      getSemanticTokens: () => {
+        calls++;
+        return Promise.resolve(tokensPayload(new Uint32Array([0, 0, 3, 0, 0])));
+      },
+    };
+
+    const ranges = await computeInjectionDecorations(zones, host);
+    expect(calls).toBe(1);
+    expect(ranges.get('keyword')!).toHaveLength(1);
+  });
+
+  it('null tokens skip the zone silently', async () => {
+    const zones = [makeZone('python', 'x', 0, 0), makeZone('rust', 'y', 5, 0)];
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python', 'rust'])),
+      getSemanticTokens: (zoneIndex) =>
+        Promise.resolve(zoneIndex === 0 ? tokensPayload(new Uint32Array([0, 0, 1, 0, 0])) : null),
+    };
+
+    const ranges = await computeInjectionDecorations(zones, host);
+    expect(ranges.get('keyword')!).toHaveLength(1);
+  });
+
+  it('thrown error skips the zone, does not bubble', async () => {
+    const zones = [makeZone('python', 'x', 0, 0), makeZone('rust', 'y', 5, 0)];
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python', 'rust'])),
+      getSemanticTokens: (zoneIndex) => {
+        if (zoneIndex === 1) return Promise.reject(new Error('provider boom'));
+        return Promise.resolve(tokensPayload(new Uint32Array([0, 0, 1, 0, 0])));
+      },
+    };
+
+    const ranges = await computeInjectionDecorations(zones, host);
+    expect(ranges.get('keyword')!).toHaveLength(1);
+  });
+
+  it('synchronous throw from getSemanticTokens is also skipped', async () => {
+    const zones = [makeZone('python', 'x', 0, 0), makeZone('rust', 'y', 5, 0)];
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python', 'rust'])),
+      getSemanticTokens: (zoneIndex) => {
+        if (zoneIndex === 1) throw new Error('sync boom');
+        return Promise.resolve(tokensPayload(new Uint32Array([0, 0, 1, 0, 0])));
+      },
+    };
+
+    const ranges = await computeInjectionDecorations(zones, host);
+    expect(ranges.get('keyword')!).toHaveLength(1);
+  });
+
+  it('empty zones returns all-empty category map', async () => {
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () =>
+        Promise.reject(new Error('should not be called when zones is empty')),
+      getSemanticTokens: () =>
+        Promise.reject(new Error('should not be called when zones is empty')),
+    };
+    const ranges = await computeInjectionDecorations([], host);
+    expect(ranges.size).toBe(7);
+    for (const [, list] of ranges) {
+      expect(list).toHaveLength(0);
+    }
+  });
+
+  it('getRegisteredLanguages called exactly once per invocation', async () => {
+    const zones = [
+      makeZone('python', 'a', 0, 0),
+      makeZone('python', 'b', 5, 0),
+      makeZone('javascript', 'c', 10, 0),
+    ];
+    let registeredCalls = 0;
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => {
+        registeredCalls++;
+        return Promise.resolve(new Set(['python', 'javascript']));
+      },
+      getSemanticTokens: () => Promise.resolve(tokensPayload(new Uint32Array([]))),
+    };
+
+    await computeInjectionDecorations(zones, host);
+    expect(registeredCalls).toBe(1);
+  });
+
+  it('zone index passed to host matches zones array index', async () => {
+    const zones = [
+      makeZone('python', 'first', 0, 0),
+      makeZone('python', 'second', 5, 0),
+      makeZone('python', 'third', 10, 0),
+    ];
+    const seen: Array<{ idx: number; content: string; lang: string }> = [];
+    const host: InjectionHostAdapter = {
+      getRegisteredLanguages: () => Promise.resolve(new Set(['python'])),
+      getSemanticTokens: (zoneIndex, content, langId) => {
+        seen.push({ idx: zoneIndex, content, lang: langId });
+        return Promise.resolve(tokensPayload(new Uint32Array([])));
+      },
+    };
+
+    await computeInjectionDecorations(zones, host);
+    expect(seen).toEqual([
+      { idx: 0, content: 'first', lang: 'python' },
+      { idx: 1, content: 'second', lang: 'python' },
+      { idx: 2, content: 'third', lang: 'python' },
+    ]);
+  });
+});

--- a/shared/test/injections/mapTokensToDecorations.test.ts
+++ b/shared/test/injections/mapTokensToDecorations.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { injections } from '@lex/shared';
+
+const { mapTokensToDecorations } = injections;
+type InjectionRange = injections.InjectionRange;
+type DecorationCategory = injections.DecorationCategory;
+type InjectionZone = injections.InjectionZone;
+
+function emptyRanges(): Map<DecorationCategory, InjectionRange[]> {
+  return new Map<DecorationCategory, InjectionRange[]>([
+    ['keyword', []],
+    ['string', []],
+    ['comment', []],
+    ['number', []],
+    ['type', []],
+    ['function', []],
+    ['operator', []],
+  ]);
+}
+
+const ZONE: InjectionZone = {
+  language: 'python',
+  text: 'placeholder',
+  startRow: 10,
+  startCol: 4,
+  endRow: 20,
+  endCol: 0,
+};
+
+// Standard LSP semantic-token legend — `keyword` at index 0, `string` at 1, etc.
+const LEGEND = {
+  tokenTypes: ['keyword', 'string', 'comment', 'number', 'operator', 'variable'],
+};
+
+describe('mapTokensToDecorations', () => {
+  it('single token on line 0 uses zone.startCol offset', () => {
+    const ranges = emptyRanges();
+    // One keyword token at (0, 2), length 3
+    const data = new Uint32Array([0, 2, 3, 0, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, ZONE, ranges);
+
+    const kw = ranges.get('keyword')!;
+    expect(kw).toHaveLength(1);
+    expect(kw[0]).toEqual({
+      startLine: 10, // zone.startRow + 0
+      startCol: 6, // zone.startCol (4) + startChar (2)
+      endLine: 10,
+      endCol: 9, // startCol + length (3)
+    });
+  });
+
+  it('multi-line delta — subsequent lines use raw startChar', () => {
+    const ranges = emptyRanges();
+    // Two tokens: keyword at virtual (0, 0) len 3, string at virtual (2, 4) len 5
+    const data = new Uint32Array([0, 0, 3, 0, 0, 2, 4, 5, 1, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, ZONE, ranges);
+
+    const kw = ranges.get('keyword')!;
+    const str = ranges.get('string')!;
+    expect(kw).toHaveLength(1);
+    expect(kw[0]).toEqual({
+      startLine: 10,
+      startCol: 4,
+      endLine: 10,
+      endCol: 7,
+    });
+    expect(str).toHaveLength(1);
+    expect(str[0]).toEqual({
+      startLine: 12,
+      startCol: 4,
+      endLine: 12,
+      endCol: 9,
+    });
+  });
+
+  it('same-line delta accumulates startChar', () => {
+    const ranges = emptyRanges();
+    const data = new Uint32Array([0, 0, 3, 0, 0, 0, 5, 4, 1, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, ZONE, ranges);
+
+    const kw = ranges.get('keyword')!;
+    const str = ranges.get('string')!;
+    expect(kw).toHaveLength(1);
+    expect(kw[0]).toEqual({
+      startLine: 10,
+      startCol: 4,
+      endLine: 10,
+      endCol: 7,
+    });
+    expect(str).toHaveLength(1);
+    expect(str[0]).toEqual({
+      startLine: 10,
+      startCol: 9,
+      endLine: 10,
+      endCol: 13,
+    });
+  });
+
+  it('unknown token-type index (out of legend) is skipped', () => {
+    const ranges = emptyRanges();
+    const data = new Uint32Array([0, 0, 3, 99, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, ZONE, ranges);
+
+    for (const [, list] of ranges) {
+      expect(list).toHaveLength(0);
+    }
+  });
+
+  it('unmapped token-type name (e.g. variable) is skipped', () => {
+    const ranges = emptyRanges();
+    const data = new Uint32Array([0, 0, 3, 5, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, ZONE, ranges);
+
+    for (const [, list] of ranges) {
+      expect(list).toHaveLength(0);
+    }
+  });
+
+  it('routes aliased token types to the right category', () => {
+    const ranges = emptyRanges();
+    const legend = {
+      tokenTypes: ['class', 'method', 'regexp', 'modifier', 'macro', 'namespace'],
+    };
+    const data = new Uint32Array([
+      0, 0, 1, 0, 0, // class → type
+      1, 0, 1, 1, 0, // method → function
+      1, 0, 1, 2, 0, // regexp → string
+      1, 0, 1, 3, 0, // modifier → keyword
+      1, 0, 1, 4, 0, // macro → function
+      1, 0, 1, 5, 0, // namespace → type
+    ]);
+    mapTokensToDecorations({ legend, data }, ZONE, ranges);
+
+    expect(ranges.get('type')!).toHaveLength(2);
+    expect(ranges.get('function')!).toHaveLength(2);
+    expect(ranges.get('string')!).toHaveLength(1);
+    expect(ranges.get('keyword')!).toHaveLength(1);
+  });
+
+  it('empty data produces no ranges', () => {
+    const ranges = emptyRanges();
+    mapTokensToDecorations({ legend: LEGEND, data: new Uint32Array([]) }, ZONE, ranges);
+    for (const [, list] of ranges) {
+      expect(list).toHaveLength(0);
+    }
+  });
+
+  it('zone with startRow=0 still maps line 0 correctly', () => {
+    const ranges = emptyRanges();
+    const zone: InjectionZone = {
+      language: 'python',
+      text: 'x',
+      startRow: 0,
+      startCol: 8,
+      endRow: 2,
+      endCol: 0,
+    };
+    const data = new Uint32Array([0, 1, 2, 0, 0]);
+    mapTokensToDecorations({ legend: LEGEND, data }, zone, ranges);
+    const kw = ranges.get('keyword')!;
+    expect(kw).toHaveLength(1);
+    expect(kw[0]).toEqual({
+      startLine: 0,
+      startCol: 9,
+      endLine: 0,
+      endCol: 11,
+    });
+  });
+});

--- a/shared/test/injections/resolveLanguageId.test.ts
+++ b/shared/test/injections/resolveLanguageId.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { injections } from '@lex/shared';
+
+const { resolveLanguageId } = injections;
+
+describe('resolveLanguageId', () => {
+  it('alias py → python when python is registered', () => {
+    const registered = new Set(['python', 'javascript', 'rust']);
+    expect(resolveLanguageId('py', registered)).toBe('python');
+  });
+
+  it('alias py returns null when python is NOT registered', () => {
+    const registered = new Set(['javascript', 'rust']);
+    expect(resolveLanguageId('py', registered)).toBe(null);
+  });
+
+  it('already-registered ID used directly', () => {
+    const registered = new Set(['python']);
+    expect(resolveLanguageId('python', registered)).toBe('python');
+  });
+
+  it('unknown alias not in registered set returns null', () => {
+    const registered = new Set(['python']);
+    expect(resolveLanguageId('cobol', registered)).toBe(null);
+  });
+
+  it('trims whitespace', () => {
+    const registered = new Set(['rust']);
+    expect(resolveLanguageId('  rust  ', registered)).toBe('rust');
+  });
+
+  it('lowercases input', () => {
+    const registered = new Set(['python']);
+    expect(resolveLanguageId('Python', registered)).toBe('python');
+    expect(resolveLanguageId('PYTHON', registered)).toBe('python');
+    expect(resolveLanguageId('PY', registered)).toBe('python');
+  });
+
+  it('empty string returns null', () => {
+    const registered = new Set(['python']);
+    expect(resolveLanguageId('', registered)).toBe(null);
+    expect(resolveLanguageId('   ', registered)).toBe(null);
+  });
+
+  it('bash/zsh/sh all alias to shellscript', () => {
+    const registered = new Set(['shellscript']);
+    expect(resolveLanguageId('bash', registered)).toBe('shellscript');
+    expect(resolveLanguageId('zsh', registered)).toBe('shellscript');
+    expect(resolveLanguageId('sh', registered)).toBe('shellscript');
+    expect(resolveLanguageId('shell', registered)).toBe('shellscript');
+  });
+
+  it('c++ aliases to cpp (special char handling)', () => {
+    const registered = new Set(['cpp']);
+    expect(resolveLanguageId('c++', registered)).toBe('cpp');
+    expect(resolveLanguageId('cxx', registered)).toBe('cpp');
+    expect(resolveLanguageId('cc', registered)).toBe('cpp');
+  });
+
+  it('jsx/tsx aliases', () => {
+    const registered = new Set(['javascriptreact', 'typescriptreact']);
+    expect(resolveLanguageId('jsx', registered)).toBe('javascriptreact');
+    expect(resolveLanguageId('tsx', registered)).toBe('typescriptreact');
+  });
+
+  it('alias does not leak when target is not registered', () => {
+    // `ts` aliases to `typescript` — if typescript is not registered but
+    // `ts` is somehow in the set, the alias resolution takes precedence
+    // and returns null (this is the intended behaviour).
+    const registered = new Set(['ts']);
+    expect(resolveLanguageId('ts', registered)).toBe(null);
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -13,6 +13,11 @@ import { buildFormattingOptions, notifyLexTest } from '@/lsp/providers/formattin
 import { navigateTableCell, formatTableAtCursor } from '@/lsp/table_commands'
 import type { LspTextEdit } from '@/lsp/types'
 import { dispatchFileTreeRefresh } from '@/lib/events'
+import { initTreeSitter } from '@/treesitter'
+import {
+  createMonacoInjectionHighlighter,
+  type MonacoInjectionHighlighterApi,
+} from '@/editor/injection_highlighter'
 
 initializeMonaco()
 
@@ -32,6 +37,7 @@ export interface EditorHandle {
   closeFile: (path: string) => void
   find: () => void
   replace: () => void
+  getInjectionHighlighter: () => MonacoInjectionHighlighterApi | null
 }
 
 export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
@@ -42,6 +48,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
   const vimModeRef = useRef<any>(null)
   const attachedStatusNodeRef = useRef<HTMLDivElement | null>(null)
+  const injectionHighlighterRef = useRef<MonacoInjectionHighlighterApi | null>(null)
   const [currentFile, setCurrentFile] = useState<string | null>(null)
   const { settings } = useSettings()
   const platform = usePlatform()
@@ -126,6 +133,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     replace: () => {
       editorRef.current?.trigger('menu', 'editor.action.startFindReplaceAction', null)
     },
+    getInjectionHighlighter: () => injectionHighlighterRef.current,
   }))
 
   useEffect(() => {
@@ -274,9 +282,24 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
       }
     })
 
+    // Embedded-code highlighter inside `:: python ::` / `:: js ::` blocks.
+    // Tree-sitter loads lazily; if the WASM artifacts are missing or the
+    // grammar fails to init, `initTreeSitter()` resolves to null and the
+    // highlighter install is skipped — LSP semantic tokens still colour
+    // the rest of the document either way.
+    void initTreeSitter().then((ts) => {
+      if (!ts || !editorRef.current) return
+      if (injectionHighlighterRef.current) {
+        injectionHighlighterRef.current.dispose()
+      }
+      injectionHighlighterRef.current = createMonacoInjectionHighlighter(editorRef.current, ts)
+    })
+
     return () => {
       tabDisposable.dispose()
       formatTableDisposable.dispose()
+      injectionHighlighterRef.current?.dispose()
+      injectionHighlighterRef.current = null
       editor.dispose()
       if (vimModeRef.current) {
         vimModeRef.current.dispose()

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -287,15 +287,20 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
     // grammar fails to init, `initTreeSitter()` resolves to null and the
     // highlighter install is skipped — LSP semantic tokens still colour
     // the rest of the document either way.
+    //
+    // The cancellation flag guards against a late-resolving init
+    // attaching a highlighter to a disposed editor after unmount.
+    let tsInitCancelled = false
     void initTreeSitter().then((ts) => {
-      if (!ts || !editorRef.current) return
+      if (tsInitCancelled || !ts || editorRef.current !== editor) return
       if (injectionHighlighterRef.current) {
         injectionHighlighterRef.current.dispose()
       }
-      injectionHighlighterRef.current = createMonacoInjectionHighlighter(editorRef.current, ts)
+      injectionHighlighterRef.current = createMonacoInjectionHighlighter(editor, ts)
     })
 
     return () => {
+      tsInitCancelled = true
       tabDisposable.dispose()
       formatTableDisposable.dispose()
       injectionHighlighterRef.current?.dispose()

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
 } from 'react'
 import { Editor, EditorHandle } from './Editor'
+import type { MonacoInjectionHighlighterApi } from '@/editor/injection_highlighter'
 import { PreviewPane } from './PreviewPane'
 import { WelcomeView } from './WelcomeView'
 import { TabBar, Tab, TabDropData } from './TabBar'
@@ -27,6 +28,7 @@ export interface EditorPaneHandle {
   format: () => Promise<void>
   getCurrentFile: () => string | null
   getEditor: () => Monaco.editor.IStandaloneCodeEditor | null
+  getInjectionHighlighter: () => MonacoInjectionHighlighterApi | null
   find: () => void
   replace: () => void
 }
@@ -323,6 +325,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
       format: handleFormat,
       getCurrentFile: () => editorRef.current?.getCurrentFile() ?? null,
       getEditor: () => editorRef.current?.getEditor() ?? null,
+      getInjectionHighlighter: () => editorRef.current?.getInjectionHighlighter() ?? null,
       find: handleFind,
       replace: handleReplace,
     }),

--- a/src/editor/injection_highlighter.css
+++ b/src/editor/injection_highlighter.css
@@ -1,0 +1,62 @@
+/*
+ * Injection highlighter colours for embedded code inside verbatim blocks.
+ * Defaults mirror the `lex.injection.*` colour IDs shipped in the vscode
+ * extension; we keep dark and light variants via `[data-theme]` on the
+ * document root (matches the rest of the lexed renderer).
+ *
+ * The `inlineClassName` from Monaco decorations lands on an inner span
+ * that already has a colour from the LSP semantic tokens pass. These
+ * selectors use `!important` so the injection colour wins over the
+ * generic `VerbatimContent` foreground.
+ */
+
+:root,
+[data-theme='dark'] {
+  --lex-injection-keyword: #569cd6;
+  --lex-injection-string: #ce9178;
+  --lex-injection-comment: #6a9955;
+  --lex-injection-number: #b5cea8;
+  --lex-injection-type: #4ec9b0;
+  --lex-injection-function: #dcdcaa;
+  --lex-injection-operator: #d4d4d4;
+}
+
+[data-theme='light'] {
+  --lex-injection-keyword: #0000ff;
+  --lex-injection-string: #a31515;
+  --lex-injection-comment: #008000;
+  --lex-injection-number: #098658;
+  --lex-injection-type: #267f99;
+  --lex-injection-function: #795e26;
+  --lex-injection-operator: #000000;
+}
+
+.lex-injection-keyword {
+  color: var(--lex-injection-keyword) !important;
+  font-weight: 600;
+}
+
+.lex-injection-string {
+  color: var(--lex-injection-string) !important;
+}
+
+.lex-injection-comment {
+  color: var(--lex-injection-comment) !important;
+  font-style: italic;
+}
+
+.lex-injection-number {
+  color: var(--lex-injection-number) !important;
+}
+
+.lex-injection-type {
+  color: var(--lex-injection-type) !important;
+}
+
+.lex-injection-function {
+  color: var(--lex-injection-function) !important;
+}
+
+.lex-injection-operator {
+  color: var(--lex-injection-operator) !important;
+}

--- a/src/editor/injection_highlighter.ts
+++ b/src/editor/injection_highlighter.ts
@@ -1,0 +1,301 @@
+/**
+ * Monaco host adapter for the shared injection highlighter.
+ *
+ * Responsibilities (matches vscode/src/injections.ts):
+ *   - Owns tree-sitter parsing (`ts.parse` + `ts.queryInjections`).
+ *   - Debounced re-highlight on content change (250 ms, same as vscode).
+ *   - Initial highlight on install, and re-highlight on language change.
+ *   - Translates the shared module's `InjectionRange[]` output into Monaco
+ *     decorations via `IEditorDecorationsCollection`.
+ *
+ * Differences from the vscode adapter:
+ *   - Monaco has no equivalent of `vscode.commands.executeCommand(
+ *     'vscode.provideDocumentSemanticTokens')` for arbitrary languages, so we
+ *     synthesise an LSP-shaped `SemanticTokens` payload from Monaco's built-in
+ *     Monarch tokenizers (`monaco.editor.tokenize`). Languages without a
+ *     Monarch tokenizer in the `monaco-editor` bundle are silently skipped,
+ *     matching the vscode behaviour of "no provider → no highlighting".
+ *   - Decorations carry an `inlineClassName` keyed by category; the actual
+ *     colours live in `src/editor/injection_highlighter.css`.
+ *   - Registered-language cache is refreshed by scanning `monaco.languages.
+ *     getLanguages()` — that set is stable for the editor lifetime so we
+ *     only fetch it once (no 30-second expiry like vscode, since newly
+ *     registered languages in a Monaco renderer are a developer event, not
+ *     a runtime one).
+ */
+
+import * as monaco from 'monaco-editor'
+import { injections } from '@lex/shared'
+import type { LexTreeSitter } from '../treesitter'
+import './injection_highlighter.css'
+
+type DecorationCategory = injections.DecorationCategory
+type InjectionZone = injections.InjectionZone
+type InjectionRange = injections.InjectionRange
+
+export interface MonacoInjectionHighlighterApi {
+  getInjectionZones(): InjectionZone[]
+  getInjectionRanges(): InjectionRange[]
+  getRangesByCategory(): ReadonlyMap<DecorationCategory, InjectionRange[]>
+  refresh(): Promise<void>
+  setEnabled(enabled: boolean): void
+  dispose(): void
+}
+
+const CATEGORY_CLASS_PREFIX = 'lex-injection'
+
+function classNameFor(category: DecorationCategory): string {
+  return `${CATEGORY_CLASS_PREFIX}-${category}`
+}
+
+interface HighlighterOptions {
+  /** Toggle from the settings UI. Defaults to true. */
+  initialEnabled?: boolean
+}
+
+export function createMonacoInjectionHighlighter(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  ts: LexTreeSitter,
+  options: HighlighterOptions = {}
+): MonacoInjectionHighlighterApi {
+  let enabled = options.initialEnabled ?? true
+  let disposed = false
+
+  const decorationsCollection = editor.createDecorationsCollection()
+  const disposables: monaco.IDisposable[] = []
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+  let currentZones: InjectionZone[] = []
+  let lastRanges: ReadonlyMap<DecorationCategory, InjectionRange[]> = new Map()
+
+  // Monaco basic-language registration is synchronous, but tokenization
+  // is lazy-loaded on first request. Prime the loader per language the
+  // first time we see it so subsequent `tokenize()` calls return real
+  // tokens instead of null-tokens.
+  const primedLanguages = new Set<string>()
+
+  let cachedLanguages: Set<string> | null = null
+
+  async function getRegisteredLanguages(): Promise<Set<string>> {
+    if (!cachedLanguages) {
+      cachedLanguages = new Set(monaco.languages.getLanguages().map((l) => l.id))
+    }
+    return cachedLanguages
+  }
+
+  async function primeLanguage(langId: string): Promise<void> {
+    if (primedLanguages.has(langId)) return
+    try {
+      // `monaco.editor.colorize` awaits the lazy tokenizer loader. Once
+      // this resolves, subsequent `monaco.editor.tokenize(...)` calls for
+      // the same language return real tokens instead of the null-state
+      // fallback.
+      await monaco.editor.colorize('', langId, { tabSize: 2 })
+    } catch {
+      // If colorize throws the language is unusable — mark it primed so
+      // we don't retry on every zone, and the null-tokens path below
+      // will silently skip it.
+    }
+    primedLanguages.add(langId)
+  }
+
+  async function getSemanticTokensForZone(
+    _zoneIndex: number,
+    content: string,
+    langId: string
+  ): Promise<injections.SemanticTokens | null> {
+    await primeLanguage(langId)
+
+    let rawTokens: monaco.Token[][]
+    try {
+      rawTokens = monaco.editor.tokenize(content, langId)
+    } catch {
+      return null
+    }
+
+    // Build the LSP-shaped legend/data pair. We emit a tiny legend (the
+    // seven shared categories) and lean on the shared module's
+    // `SEMANTIC_TOKEN_MAP` to route each token type.
+    const legend = {
+      tokenTypes: Object.keys(injections.SEMANTIC_TOKEN_MAP),
+    }
+    const typeIndex = new Map<string, number>()
+    for (let i = 0; i < legend.tokenTypes.length; i++) {
+      typeIndex.set(legend.tokenTypes[i], i)
+    }
+
+    const lines = content.split(/\r\n|\r|\n/)
+    const data: number[] = []
+    let prevLine = 0
+    let prevStart = 0
+    let emittedAny = false
+
+    for (let lineIdx = 0; lineIdx < rawTokens.length; lineIdx++) {
+      const tokens = rawTokens[lineIdx]
+      if (!tokens || tokens.length === 0) continue
+
+      const lineText = lines[lineIdx] ?? ''
+
+      for (let t = 0; t < tokens.length; t++) {
+        const token = tokens[t]
+        const nextOffset = t + 1 < tokens.length ? tokens[t + 1].offset : lineText.length
+        const length = nextOffset - token.offset
+        if (length <= 0) continue
+
+        // Monaco token types look like "keyword.python" or "string.quoted.python" —
+        // strip everything from the first dot onwards, since our shared
+        // `SEMANTIC_TOKEN_MAP` keys are bare type names like "keyword",
+        // "string", "comment", etc.
+        const baseType = token.type.split('.')[0]
+        if (!baseType) continue
+
+        const idx = typeIndex.get(baseType)
+        if (idx === undefined) continue
+
+        const deltaLine = lineIdx - prevLine
+        const deltaStart = deltaLine === 0 ? token.offset - prevStart : token.offset
+        data.push(deltaLine, deltaStart, length, idx, 0)
+        prevLine = lineIdx
+        prevStart = token.offset
+        emittedAny = true
+      }
+    }
+
+    if (!emittedAny) return null
+    return { legend, data: new Uint32Array(data) }
+  }
+
+  const hostAdapter: injections.InjectionHostAdapter = {
+    getRegisteredLanguages,
+    getSemanticTokens: getSemanticTokensForZone,
+  }
+
+  function clearDecorations(): void {
+    decorationsCollection.clear()
+    currentZones = []
+    lastRanges = new Map()
+  }
+
+  async function highlight(): Promise<void> {
+    if (disposed) return
+    const model = editor.getModel()
+    if (!model || model.isDisposed()) {
+      clearDecorations()
+      return
+    }
+    if (!enabled || model.getLanguageId() !== 'lex') {
+      clearDecorations()
+      return
+    }
+
+    const text = model.getValue()
+    let zones: InjectionZone[]
+    try {
+      const tree = ts.parse(text)
+      zones = ts.queryInjections(tree)
+      tree.delete()
+    } catch (err) {
+      console.warn('[lex] tree-sitter parse failed:', err)
+      return
+    }
+    currentZones = zones
+
+    const ranges = await injections.computeInjectionDecorations(zones, hostAdapter)
+
+    // Guard against rapid-fire changes: if the model has been swapped or
+    // the highlighter disposed while we were awaiting, drop the result.
+    if (disposed) return
+    if (editor.getModel() !== model || model.isDisposed()) return
+
+    lastRanges = ranges
+
+    const newDecorations: monaco.editor.IModelDeltaDecoration[] = []
+    for (const [category, rs] of ranges) {
+      if (rs.length === 0) continue
+      const className = classNameFor(category)
+      for (const r of rs) {
+        // Shared module emits zero-based line/col; Monaco is one-based.
+        newDecorations.push({
+          range: new monaco.Range(r.startLine + 1, r.startCol + 1, r.endLine + 1, r.endCol + 1),
+          options: {
+            inlineClassName: className,
+            // Ensure we render alongside (not over) the LSP semantic
+            // tokens — `inlineClassName` layers over the existing syntax
+            // colouring, it does not replace it.
+            shouldFillLineOnLineBreak: false,
+          },
+        })
+      }
+    }
+    decorationsCollection.set(newDecorations)
+  }
+
+  function scheduleHighlight(): void {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined
+      void highlight()
+    }, injections.DEBOUNCE_MS)
+  }
+
+  // Watch the current model for content + language changes.
+  let modelListeners: monaco.IDisposable[] = []
+  function attachModelListeners(model: monaco.editor.ITextModel): void {
+    for (const d of modelListeners) d.dispose()
+    modelListeners = []
+    modelListeners.push(model.onDidChangeContent(() => scheduleHighlight()))
+    modelListeners.push(model.onDidChangeLanguage(() => void highlight()))
+    modelListeners.push(model.onWillDispose(() => clearDecorations()))
+  }
+
+  const currentModel = editor.getModel()
+  if (currentModel) attachModelListeners(currentModel)
+
+  disposables.push(
+    editor.onDidChangeModel(() => {
+      clearDecorations()
+      const nextModel = editor.getModel()
+      if (nextModel) {
+        attachModelListeners(nextModel)
+        void highlight()
+      }
+    })
+  )
+
+  disposables.push(
+    editor.onDidDispose(() => {
+      dispose()
+    })
+  )
+
+  // Initial highlight (fire-and-forget — the caller doesn't await).
+  void highlight()
+
+  function dispose(): void {
+    if (disposed) return
+    disposed = true
+    if (debounceTimer) clearTimeout(debounceTimer)
+    decorationsCollection.clear()
+    for (const d of modelListeners) d.dispose()
+    modelListeners = []
+    for (const d of disposables) d.dispose()
+  }
+
+  return {
+    getInjectionZones: () => currentZones,
+    getInjectionRanges: () => {
+      const all: InjectionRange[] = []
+      for (const [, rs] of lastRanges) {
+        for (const r of rs) all.push(r)
+      }
+      return all
+    },
+    getRangesByCategory: () => lastRanges,
+    refresh: () => highlight(),
+    setEnabled(next: boolean) {
+      if (enabled === next) return
+      enabled = next
+      void highlight()
+    },
+    dispose,
+  }
+}

--- a/src/editor/injection_highlighter.ts
+++ b/src/editor/injection_highlighter.ts
@@ -187,6 +187,12 @@ export function createMonacoInjectionHighlighter(
       return
     }
 
+    // Capture the model version before the async work so we can detect
+    // an overlapping `highlight()` that started more recently and should
+    // win. Without this, an older pass can resolve after a newer one and
+    // overwrite decorations with stale ranges for the same model.
+    const versionBeforeParse = model.getVersionId()
+
     const text = model.getValue()
     let zones: InjectionZone[]
     try {
@@ -195,6 +201,7 @@ export function createMonacoInjectionHighlighter(
       tree.delete()
     } catch (err) {
       console.warn('[lex] tree-sitter parse failed:', err)
+      clearDecorations()
       return
     }
     currentZones = zones
@@ -203,8 +210,11 @@ export function createMonacoInjectionHighlighter(
 
     // Guard against rapid-fire changes: if the model has been swapped or
     // the highlighter disposed while we were awaiting, drop the result.
+    // Also drop if a newer highlight pass started after us (versionId
+    // advanced while we were awaiting getSemanticTokens).
     if (disposed) return
     if (editor.getModel() !== model || model.isDisposed()) return
+    if (model.getVersionId() !== versionBeforeParse) return
 
     lastRanges = ranges
 

--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -202,6 +202,42 @@ export function useLexTestBridge({
         await action.run()
         return true
       },
+
+      // Injection highlighter introspection — exposed so e2e tests can
+      // verify that embedded code inside `:: <lang> ::` verbatim blocks
+      // gets categorised tokens back from the Monaco host adapter.
+      getInjectionZones: () => {
+        const target = activePaneId ?? panesRef.current[0]?.id ?? null
+        if (!target) return []
+        const highlighter = paneHandles.current.get(target)?.getInjectionHighlighter()
+        return highlighter?.getInjectionZones() ?? []
+      },
+      getInjectionRanges: () => {
+        const target = activePaneId ?? panesRef.current[0]?.id ?? null
+        if (!target) return []
+        const highlighter = paneHandles.current.get(target)?.getInjectionHighlighter()
+        return highlighter?.getInjectionRanges() ?? []
+      },
+      getInjectionRangesByCategory: () => {
+        const target = activePaneId ?? panesRef.current[0]?.id ?? null
+        if (!target) return {}
+        const highlighter = paneHandles.current.get(target)?.getInjectionHighlighter()
+        const byCategory = highlighter?.getRangesByCategory()
+        if (!byCategory) return {}
+        const out: Record<string, unknown[]> = {}
+        for (const [cat, ranges] of byCategory) {
+          out[cat] = ranges
+        }
+        return out
+      },
+      refreshInjectionHighlighter: async () => {
+        const target = activePaneId ?? panesRef.current[0]?.id ?? null
+        if (!target) return false
+        const highlighter = paneHandles.current.get(target)?.getInjectionHighlighter()
+        if (!highlighter) return false
+        await highlighter.refresh()
+        return true
+      },
     }
     window.lexTest = api
     return () => {

--- a/src/treesitter.ts
+++ b/src/treesitter.ts
@@ -1,0 +1,175 @@
+/**
+ * Renderer-side tree-sitter wrapper for the lex grammar. Parallels
+ * vscode/src/treesitter.ts but uses Vite's `?url` loaders to point
+ * web-tree-sitter at the bundled WASM artifacts, since the renderer runs
+ * under Chromium (not Node) and cannot use `fs.readFileSync` directly.
+ *
+ * The runtime `tree-sitter.wasm` ships inside the `web-tree-sitter` package
+ * and is fingerprinted by Vite. The lex grammar `tree-sitter-lex.wasm` plus
+ * the `.scm` queries live in `resources/` and are downloaded by
+ * `scripts/download-tree-sitter.sh` at install / build time.
+ *
+ * Each `initTreeSitter()` call resolves to a `LexTreeSitter` instance or
+ * `null` — the module mirrors the vscode adapter's fallback contract
+ * (caller can no-op the injection highlighter when tree-sitter is
+ * unavailable, e.g. during a dev cycle before the artifacts land).
+ */
+
+import { Parser, Language, Query, type Tree, type Node } from 'web-tree-sitter'
+import runtimeWasmUrl from 'web-tree-sitter/tree-sitter.wasm?url'
+import grammarWasmUrl from '../resources/tree-sitter-lex.wasm?url'
+import highlightsQuerySrc from '../resources/queries/highlights.scm?raw'
+import injectionsQuerySrc from '../resources/queries/injections.scm?raw'
+
+export type { Tree, Node }
+
+export interface CaptureResult {
+  name: string
+  startRow: number
+  startCol: number
+  endRow: number
+  endCol: number
+  text: string
+}
+
+export interface InjectionZone {
+  language: string
+  startRow: number
+  startCol: number
+  endRow: number
+  endCol: number
+  text: string
+}
+
+export interface LexTreeSitter {
+  parse(text: string): Tree
+  queryHighlights(tree: Tree): CaptureResult[]
+  queryInjections(tree: Tree): InjectionZone[]
+  dispose(): void
+}
+
+let initPromise: Promise<LexTreeSitter | null> | null = null
+
+/**
+ * Lazy singleton — subsequent callers share the same parser/queries. Also
+ * memoises failures: if the WASM load fails once (e.g. the grammar file
+ * wasn't downloaded), we don't retry on every editor mount.
+ */
+export function initTreeSitter(): Promise<LexTreeSitter | null> {
+  if (!initPromise) {
+    initPromise = loadTreeSitter()
+  }
+  return initPromise
+}
+
+async function loadTreeSitter(): Promise<LexTreeSitter | null> {
+  try {
+    await Parser.init({
+      locateFile: () => runtimeWasmUrl,
+    })
+
+    const language = await Language.load(grammarWasmUrl)
+    const parser = new Parser()
+    parser.setLanguage(language)
+
+    const highlightsQuery = new Query(language, highlightsQuerySrc)
+
+    let injectionsQuery: Query | null = null
+    if (injectionsQuerySrc && injectionsQuerySrc.trim().length > 0) {
+      try {
+        injectionsQuery = new Query(language, injectionsQuerySrc)
+      } catch (err) {
+        console.warn('[lex] injections query failed to compile:', err)
+      }
+    }
+
+    return {
+      parse(text: string): Tree {
+        const tree = parser.parse(text)
+        if (!tree) throw new Error('tree-sitter parse returned null')
+        return tree
+      },
+
+      queryHighlights(tree: Tree): CaptureResult[] {
+        const captures = highlightsQuery.captures(tree.rootNode)
+        return captures.map((c) => ({
+          name: c.name,
+          startRow: c.node.startPosition.row,
+          startCol: c.node.startPosition.column,
+          endRow: c.node.endPosition.row,
+          endCol: c.node.endPosition.column,
+          text: c.node.text,
+        }))
+      },
+
+      queryInjections(tree: Tree): InjectionZone[] {
+        if (!injectionsQuery) return []
+
+        const captures = injectionsQuery.captures(tree.rootNode)
+        const zones: InjectionZone[] = []
+
+        const contentCaptures: Array<{
+          node: CaptureResult
+          parentId: number
+        }> = []
+        const langCaptures: Array<{
+          lang: string
+          parentId: number
+        }> = []
+
+        for (const capture of captures) {
+          const parentNode = capture.node.parent
+          const parentId = parentNode?.id ?? 0
+
+          if (capture.name === 'injection.content') {
+            contentCaptures.push({
+              node: {
+                name: capture.name,
+                startRow: capture.node.startPosition.row,
+                startCol: capture.node.startPosition.column,
+                endRow: capture.node.endPosition.row,
+                endCol: capture.node.endPosition.column,
+                text: capture.node.text,
+              },
+              parentId,
+            })
+          } else if (capture.name === 'injection.language') {
+            const raw = capture.node.text.trim()
+            const lang = raw.split(/\s+/)[0].toLowerCase()
+            langCaptures.push({ lang, parentId })
+          }
+        }
+
+        const langByParent = new Map<number, string>()
+        for (const lc of langCaptures) {
+          langByParent.set(lc.parentId, lc.lang)
+        }
+
+        for (const cc of contentCaptures) {
+          const lang = langByParent.get(cc.parentId)
+          if (lang) {
+            zones.push({
+              language: lang,
+              startRow: cc.node.startRow,
+              startCol: cc.node.startCol,
+              endRow: cc.node.endRow,
+              endCol: cc.node.endCol,
+              text: cc.node.text,
+            })
+          }
+        }
+
+        return zones
+      },
+
+      dispose() {
+        parser.delete()
+        highlightsQuery.delete()
+        injectionsQuery?.delete()
+      },
+    }
+  } catch (err) {
+    console.warn('[lex] Failed to initialize tree-sitter:', err)
+    return null
+  }
+}

--- a/tests/e2e/injection-highlighting.spec.ts
+++ b/tests/e2e/injection-highlighting.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from './lib'
+import { openFixture } from './helpers'
+
+/**
+ * Injection highlighting inside `:: <lang> ::` verbatim blocks.
+ *
+ * The renderer ports `@lex/shared/injections` (from vscode) on top of a
+ * Monaco host adapter that feeds back Monaco's built-in Monarch
+ * tokenizers. We verify the end-to-end pipeline — tree-sitter parse →
+ * zone detection → host-adapter semantic tokens → decoration ranges —
+ * by opening a fixture with two annotated blocks and asserting the
+ * shared module produced ranges that fall inside each block. The exact
+ * colours are the host's business; we only care that *some* tokens are
+ * categorised, and that they live inside the annotated zones (not in
+ * the surrounding prose).
+ *
+ * Two assertions lift the bar beyond "some ranges exist":
+ *   1. Every returned range falls within one of the tree-sitter injection
+ *      zones (nothing leaks into prose lines).
+ *   2. Both the Python and JavaScript zones contribute at least one range,
+ *      meaning the alias resolution + per-language tokenizer priming work
+ *      for both.
+ */
+
+interface InjectionRange {
+  startLine: number
+  startCol: number
+  endLine: number
+  endCol: number
+}
+
+interface InjectionZone {
+  language: string
+  startRow: number
+  endRow: number
+}
+
+test.describe('Injection Highlighting', () => {
+  test('produces categorised ranges inside :: python :: and :: javascript :: blocks', async ({
+    page,
+  }) => {
+    test.setTimeout(30_000)
+
+    await openFixture(page, 'injection-sample.lex')
+
+    // Tree-sitter WASM and each Monarch tokenizer load asynchronously;
+    // the shared module's debounce window is 250 ms. Poll until we see
+    // zones for both languages (tree-sitter ready) and then until at
+    // least one range lands (host adapter ready).
+    await expect
+      .poll(
+        async () => {
+          const zones = (await page.evaluate(() =>
+            (window as any).lexTest?.getInjectionZones?.()
+          )) as InjectionZone[] | undefined
+          if (!zones) return 0
+          const langs = new Set(zones.map((z) => z.language))
+          return (langs.has('python') ? 1 : 0) + (langs.has('javascript') ? 1 : 0)
+        },
+        { timeout: 15_000, message: 'Waiting for tree-sitter to detect both injection zones' }
+      )
+      .toBe(2)
+
+    // Force a refresh so we don't race against the debounce timer.
+    await page.evaluate(() => (window as any).lexTest.refreshInjectionHighlighter())
+
+    await expect
+      .poll(
+        async () => {
+          const ranges = (await page.evaluate(() =>
+            (window as any).lexTest?.getInjectionRanges?.()
+          )) as InjectionRange[] | undefined
+          return ranges?.length ?? 0
+        },
+        { timeout: 10_000, message: 'Waiting for injection ranges to materialise' }
+      )
+      .toBeGreaterThan(0)
+
+    const { zones, ranges, byCategory } = await page.evaluate(() => {
+      const api = (window as any).lexTest
+      return {
+        zones: api.getInjectionZones() as InjectionZone[],
+        ranges: api.getInjectionRanges() as InjectionRange[],
+        byCategory: api.getInjectionRangesByCategory() as Record<string, InjectionRange[]>,
+      }
+    })
+
+    expect(zones.length).toBeGreaterThanOrEqual(2)
+    const pythonZone = zones.find((z) => z.language === 'python')!
+    const javascriptZone = zones.find((z) => z.language === 'javascript')!
+    expect(pythonZone).toBeDefined()
+    expect(javascriptZone).toBeDefined()
+
+    // Every range must fall inside some zone's line span.
+    const zoneContains = (r: InjectionRange) =>
+      zones.some((z) => r.startLine >= z.startRow && r.endLine <= z.endRow)
+    for (const r of ranges) {
+      expect(
+        zoneContains(r),
+        `range ${JSON.stringify(r)} should fall inside an injection zone`
+      ).toBe(true)
+    }
+
+    // Both zones must contribute at least one range — confirms both the
+    // Python and JavaScript tokenizers wired through the host adapter.
+    const pythonRanges = ranges.filter(
+      (r) => r.startLine >= pythonZone.startRow && r.endLine <= pythonZone.endRow
+    )
+    const javascriptRanges = ranges.filter(
+      (r) => r.startLine >= javascriptZone.startRow && r.endLine <= javascriptZone.endRow
+    )
+    expect(pythonRanges.length).toBeGreaterThan(0)
+    expect(javascriptRanges.length).toBeGreaterThan(0)
+
+    // Categorised output: at least two distinct categories should fire
+    // across the two blocks (keyword + one of string/number/function).
+    const nonEmptyCategories = Object.entries(byCategory)
+      .filter(([, rs]) => Array.isArray(rs) && rs.length > 0)
+      .map(([cat]) => cat)
+    expect(nonEmptyCategories.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('injection decoration DOM classes show up under the editor', async ({ page }) => {
+    test.setTimeout(30_000)
+    await openFixture(page, 'injection-sample.lex')
+
+    // Wait for ranges to apply, then verify the DOM carries the
+    // `lex-injection-*` inline classes (at least one category).
+    await expect
+      .poll(
+        async () => {
+          const count = await page.evaluate(() => {
+            const ranges = (window as any).lexTest?.getInjectionRanges?.() as
+              | InjectionRange[]
+              | undefined
+            return ranges?.length ?? 0
+          })
+          return count
+        },
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(0)
+
+    // Any element carrying a `lex-injection-*` class means the Monaco
+    // `inlineClassName` landed on the rendered tokens.
+    await expect
+      .poll(
+        async () =>
+          (await page.locator('[class*="lex-injection-"]').count()) +
+          // Monaco also splits classes across tokens; fall back on the category
+          // prefix if the above selector misses (some versions flatten the
+          // class list).
+          (await page.locator('.lex-injection-keyword').count()),
+        { timeout: 15_000, message: 'Waiting for injection decoration DOM' }
+      )
+      .toBeGreaterThan(0)
+  })
+})

--- a/tests/fixtures/injection-sample.lex
+++ b/tests/fixtures/injection-sample.lex
@@ -1,0 +1,33 @@
+Injection Highlighting Sample
+-----------------------------
+
+This fixture is used by `tests/e2e/injection-highlighting.spec.ts`. The
+two verbatim blocks below carry `:: python ::` and `:: javascript ::`
+closing annotations — the injection highlighter should detect them via
+tree-sitter and apply categorised decorations over each block's content.
+
+Python example:
+
+    def greet(name):
+        return "hello " + name
+
+    class Greeter:
+        def __init__(self, prefix):
+            self.prefix = prefix
+
+:: python ::
+
+Some plain prose between the blocks. This line must *not* be decorated
+by the injection highlighter — only the verbatim content should be.
+
+JavaScript example:
+
+    const x = 42;
+    function add(a, b) {
+        return a + b;
+    }
+    // a trailing comment
+
+:: javascript ::
+
+Closing prose — again, no injection decorations here.


### PR DESCRIPTION
## Summary

Lands the embedded-code highlighter inside `:: <lang> ::` verbatim blocks on top of the shared injection module extracted for vscode#23. Four stacked commits:

1. **Shared module copy** — `shared/src/injections/` ported verbatim from `lex-fmt/vscode`, re-exported as `@lex/shared.injections`. 27 unit tests ported from node:test to vitest (byte-identical assertions); 116 unit tests pass.
2. **Tree-sitter plumbing** — `web-tree-sitter@0.25.10` added as a renderer dep. `shared/lex-deps.json` gains a `tree-sitter` entry pinned to `v0.8.3` from `lex-fmt/tree-sitter-lex`; `scripts/download-tree-sitter.sh` fetches the grammar WASM + `.scm` queries into `resources/` at install / build time. `scripts/fetch-deps.sh` skips the tree-sitter entry (different archive layout). `src/treesitter.ts` exposes a lazy-singleton `initTreeSitter()` wrapper around Parser/Language/Query, loading the runtime WASM from `node_modules` via Vite's `?url` import and the grammar + queries from `resources/` the same way — no Node `fs` in the renderer.
3. **Monaco host adapter + editor lifecycle** — `src/editor/injection_highlighter.{ts,css}` implements the Monaco side of `InjectionHostAdapter` and wires it into the `Editor` component. Exposes `EditorHandle.getInjectionHighlighter()` through `EditorPane` so `useLexTestBridge` can surface it as `window.lexTest.getInjectionZones() / getInjectionRanges() / getInjectionRangesByCategory() / refreshInjectionHighlighter()`.
4. **E2E fixture + spec** — `tests/fixtures/injection-sample.lex` (Python + JavaScript verbatim blocks) and `tests/e2e/injection-highlighting.spec.ts`. Two test cases: one asserts both zones yield categorised ranges that fall inside the annotated blocks, the other asserts the `lex-injection-*` inline classes land in the rendered DOM.

Closes #24.

## How the Monaco adapter differs from the vscode adapter

- **Semantic-token source.** vscode's adapter calls `vscode.commands.executeCommand('vscode.provideDocumentSemanticTokens', uri)` against a virtual doc with the embedded language. Monaco has no such cross-language semantic-tokens pipe, so the Monaco adapter synthesises an LSP-shaped `SemanticTokens` payload from `monaco.editor.tokenize(content, langId)` (Monarch tokenizers shipped with the `monaco-editor` package). Token types like `keyword.python` or `string.quoted.python` are reduced to their first dot-separated segment (`keyword`, `string`) and matched against the shared `SEMANTIC_TOKEN_MAP`. Languages without a Monarch tokenizer are silently skipped — same "no provider, no highlighting" behaviour as vscode.
- **Tokenizer priming.** Monaco's basic languages are registered synchronously but their tokenizers lazy-load on first request. A cold `monaco.editor.tokenize()` returns null-state tokens. The adapter primes each language once via `await monaco.editor.colorize('', langId, {})` (awaits the loader) before tokenizing; primed languages are cached per-highlighter.
- **Decorations.** `IEditorDecorationsCollection.set()` with an `inlineClassName` per category. Colours live in `src/editor/injection_highlighter.css` keyed to `--lex-injection-*` CSS vars with dark / light defaults that mirror vscode's `lex.injection.*` theme-color IDs.
- **Registered-languages cache.** Monaco's language set is stable for the editor lifetime, so the adapter caches it once (no 30-second expiry vscode uses to pick up newly installed extensions).
- **Coordinate system.** Monaco decorations use 1-based lines / 1-based columns in UTF-16 units; the shared module emits 0-based lines / 0-based cols in the same UTF-16 units. Conversion is `+1` per coordinate in the adapter — no byte / code-point conversion needed.

## Verification

Run from `/Users/adebert/h/lex-fmt/lexed`:

- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npm run test:unit -- --run` — **116 tests pass** (89 pre-existing + 27 new shared injections).
- `npm run test:e2e:dev` — **38 passed, 1 skipped** (2 new in `injection-highlighting.spec.ts`).
- `npx vite build` — bundles cleanly (`tree-sitter.wasm` and `tree-sitter-lex.wasm` land in `dist/assets/`).
- `npm run build` (full electron-builder pipeline, run by the pre-commit hook on every commit) — green across all four commits.

## Unresolved / follow-ups

- **Settings UI toggle not exposed.** `MonacoInjectionHighlighterApi.setEnabled(enabled)` is implemented and wired internally, but the `SettingsDialog` isn't extended with a user-facing toggle in this PR. Follow-up task: thread an `injectionHighlighting` field into `EditorSettings` + the `Editor` useEffect, matching vscode's `lex.injectionHighlighting` default-true config.
- **Per-theme colour customisation.** The CSS in `src/editor/injection_highlighter.css` hardcodes vscode's default palette. If the Monaco `lex-monochrome` theme evolves, we may want to drive `--lex-injection-*` from the theme definition rather than from `[data-theme]` blocks in CSS.
- **Bundle size.** Vite reports the main chunk at 5.1 MB (gzip 1.28 MB). Monaco's Monarch tokenizers for 82 languages are the bulk; injection highlighting pulls in no new code here (they were already loaded via `monaco-editor/esm/vs/editor/editor.main.js`). Dynamic-import code-splitting is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)