### PR TITLE
Bump pinned LSP version to v0.8.6

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.8.5",
+      "version": "v0.8.6",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {


### PR DESCRIPTION
## Summary

Bumps `shared/lex-deps.json` `lexd-lsp` pin from `v0.8.5` to `v0.8.6`.

v0.8.6 ships the **Add missing footnote definition** quickfix (lex-fmt/lex#463). With this bump, lexed users see the quickfix on `missing-footnote` diagnostics through Monaco's code-action menu (the existing `monaco-languageclient` wiring forwards code actions automatically).

## Test plan
- [x] Pre-commit pipeline green (lint, tsc, unit, e2e)
- [ ] Manual: open a `.lex` file with `[1]` referenced but not defined; trigger Monaco's code-action menu; confirm "Add definition for footnote [1]" appears and applies a sensible edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)