### PR TITLE
Bump pinned LSP version to v0.8.8

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.8.7",
+      "version": "v0.8.8",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {


### PR DESCRIPTION
## Summary

Bumps `shared/lex-deps.json` `lexd-lsp` pin from `v0.8.7` to `v0.8.8`.

v0.8.8 is the first release containing the **Add missing footnote definition** quickfix (lex-fmt/lex#463). The PR landed on `main` after v0.8.6 and v0.8.7 had already shipped, so neither earlier release surfaces it.

With this bump, lexed users see the quickfix on `missing-footnote` diagnostics through Monaco's `monaco-languageclient` code-action flow — no app code change required.

## Test plan
- [x] CI green (build, unit, e2e)
- [ ] Manual: open a `.lex` document with `[1]` referenced but not defined; trigger code action (Cmd+.); confirm "Add definition for footnote [1]" appears and inserts a `:: notes ::` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)