### PR TITLE
chore(ci): add CODEOWNERS + Copilot review workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arthur-debert

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,15 @@
+name: Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Phase 2 of the non-rust GitHub-side standardization (`~/h/repo-all/tooling.lex` §12). Adds two stack-agnostic policy files:

- `.github/CODEOWNERS` — `* @arthur-debert`
- `.github/workflows/copilot-review.yml` — auto-triggers Copilot review on every PR via the reusable workflow at `arthur-debert/gh-dagentic`

Both files copied verbatim from `~/h/dotfiles/gh/templates/rust/`. Identical to the rust-canonical setup landed in dodot, padz, simple-gal, etc.

Companion to the `main-branch-protection` ruleset that landed via `gh api` in Phase 1.

Phase 3-4 will add stack-tailored `dependabot.yml`, `copilot-instructions.md`, and `pull_request_template.md` once per-stack templates are authored.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI tooling, no behavior change)
- [x] Project umbrella check passes locally — N/A (config-only)
- [x] Tests added or updated for behavior changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)