### PR TITLE
chore(ci): add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with `npm` + `github-actions` ecosystems on weekly cadence. Mirrors the rust-canonical setup (which uses `cargo` + `github-actions`); same shape, ecosystem swapped.

This is the high-value piece of what would otherwise be a "node-stack template" — automated weekly dependency PRs. Per `~/h/repo-all/tooling.lex` §12.2, the other stack-tailored files (copilot-instructions, PR template) have a delta of only 1-10 lines vs the rust template, so they're skipped — `dependabot.yml` is the only file that produces ongoing value.

Companion to:
- main-branch-protection ruleset (Phase 1, applied via `gh api`)
- CODEOWNERS + copilot-review.yml (Phase 2, currently open in a sibling PR)

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI tooling)
- [x] Project umbrella check passes locally — N/A (config only)
- [x] Tests added or updated for behavior changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)