### PR TITLE
fix(e2e): hide macOS dock icon when E2E_HIDE_WINDOW=1

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,15 @@ if (userDataOverride) {
   app.setPath('userData', path.resolve(userDataOverride))
 }
 
+// Hide the macOS dock entry during E2E so test launches don't bounce the
+// dock and steal focus from whatever the developer is working on locally.
+// `show: false` on the BrowserWindow alone doesn't prevent the dock entry —
+// macOS registers it the moment whenReady() resolves. Must run before
+// app.whenReady().
+if (process.env.E2E_HIDE_WINDOW === '1' && process.platform === 'darwin') {
+  app.dock?.hide()
+}
+
 // During E2E runs (E2E_HIDE_WINDOW=1) the renderer window is created with
 // `show: false`. Routing and second-instance handlers can still call
 // `win.focus()` / `restoreAndFocus`, which on macOS makes a hidden window


### PR DESCRIPTION
## Summary

When running `pnpm test:e2e` locally on macOS, the lexed BrowserWindow is correctly hidden (`E2E_HIDE_WINDOW=1` → `show: false`), but the **macOS Dock icon** still bounces and steals focus on every test launch. Electron registers the dock entry the moment `app.whenReady()` resolves, independently of any window's visibility.

Fix: call `app.dock?.hide()` early (before `app.whenReady()`) when running under E2E on darwin.

```ts
if (process.env.E2E_HIDE_WINDOW === '1' && process.platform === 'darwin') {
  app.dock?.hide()
}
```

This was a gap in the canonical `electron-e2e-testing` skill — that skill has been updated in tandem to recommend the dock-hide pattern alongside `E2E_HIDE_WINDOW`. simple-gal-ui (the other electron app in scope) is getting the same fix in a parallel PR.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (test-only behavior change, no user-facing impact)
- [x] Project umbrella check passes locally — TypeScript compiles
- [x] Tests added or updated for behavior changes — N/A (e2e behavior fix; verified locally that dock no longer appears during `pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)