### PR TITLE
chore(ci): group dependabot PRs and auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,65 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "eslint-plugin-*"
+      types:
+        patterns: ["@types/*"]
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+      electron:
+        patterns:
+          - "electron"
+          - "electron-*"
+          - "@electron/*"
+      monaco:
+        patterns:
+          - "monaco-*"
+          - "@monaco-editor/*"
+      playwright:
+        patterns:
+          - "playwright"
+          - "@playwright/*"
+    ignore:
+      # New react-hooks/refs rule flags existing code; needs React refactor (see #40).
+      - dependency-name: eslint-plugin-react-hooks
+        versions: [">= 5"]
+      # Renderer build error — API change needs investigation (see #44).
+      - dependency-name: web-tree-sitter
+        versions: [">= 0.26"]
+      # @types/node should track the chosen Node runtime, not jump majors blindly.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # TypeScript major bumps need coordinated migration.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: /shared
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      shared-types:
+        patterns: ["@types/*"]
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
         patterns:
           - "eslint"
           - "eslint-*"
+          - "@eslint/*"
           - "@typescript-eslint/*"
           - "eslint-plugin-*"
       types:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reduce dependabot noise so humans only see PRs that need real attention.

## Changes

**Groups** (`.github/dependabot.yml`)
- `eslint`: eslint, eslint-*, @typescript-eslint/*, eslint-plugin-* — peer-deps that must move together
- `types`: @types/*
- `vite`, `electron`, `monaco`, `playwright`: per-stack groupings
- `gh-actions`: all GitHub Actions bumps
- `shared/` ecosystem also gets a `shared-types` group

**Ignores**
- eslint-plugin-react-hooks >= 5 — new react-hooks/refs rule needs React refactor (see #40)
- web-tree-sitter >= 0.26 — renderer build error needs investigation (see #44)
- @types/node majors — should track chosen Node runtime intentionally
- typescript majors — needs coordinated migration

**Auto-merge** (`.github/workflows/dependabot-auto-merge.yml`)
- Patch and minor (and grouped patch/minor) auto-merge once CI passes
- Majors still surface as PRs for human review

After this lands I'll close the existing dependabot backlog (#40, #42, #44, #46-#49); they'll be re-emitted on next sweep as the new grouped PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)