### PR TITLE
ci: retry gh pr merge --auto to handle CI race

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        # Retry: `gh pr merge --auto` fails with "Pull request is in unstable
+        # status" if CI hasn't started yet on a freshly-opened PR.
+        run: |
+          for i in 1 2 3 4 5 6; do
+            if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
+              exit 0
+            fi
+            sleep 30
+          done
+          exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #51. `gh pr merge --auto` fails with 'Pull request is in unstable status' if CI hasn't started yet on a freshly-opened PR. Retry up to 6 times with 30s delay so we land in the stable-checks window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)