### PR TITLE
fix(electron): bundle main process as CJS to unblock e2e

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,4 @@
 import { app, BaseWindow, BrowserWindow, ipcMain, dialog, nativeTheme, shell, Menu } from 'electron'
-import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import * as fs from 'fs/promises'
 import * as fsSync from 'fs'
@@ -94,7 +93,10 @@ log.info('Logging initialised', {
 // Optional: Catch all unhandled errors
 log.errorHandler.startCatching()
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// Note: __dirname is the CJS built-in here; vite-plugin-electron emits
+// dist-electron/main.cjs in CommonJS format so the runtime provides it.
+// The previous `path.dirname(fileURLToPath(import.meta.url))` workaround
+// was for ESM mode and would throw under CJS (import.meta.url is undefined).
 
 type ThemeMode = 'dark' | 'light'
 

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -1,9 +1,12 @@
 import { app, BrowserWindow, nativeTheme } from 'electron'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// __dirname is the CJS built-in (main process bundles to .cjs). The
+// previous `path.dirname(fileURLToPath(import.meta.url))` workaround
+// was for ESM mode; it throws under CJS because import.meta.url is
+// undefined. See lex-fmt/lexed#69.
+
 import { randomUUID } from 'crypto'
 import { LspManager } from './lsp-manager'
 import Store from 'electron-store'

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "type": "git",
     "url": "https://github.com/lex-fmt/lexed.git"
   },
-  "main": "dist-electron/main.js",
+  "main": "dist-electron/main.cjs",
   "build": {
     "publish": {
       "provider": "github",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,38 @@ export default defineConfig({
       main: {
         // Shortcut of `build.lib.entry`.
         entry: 'electron/main.ts',
+        // Force CJS output for the main process. The repo's
+        // package.json sets `"type": "module"`, which would otherwise
+        // make vite-plugin-electron's resolveViteConfig() default
+        // build.lib.formats to ['es'] (see node_modules/vite-plugin-
+        // electron/dist/index.mjs). The bundled CJS deps
+        // (electron-log, electron-updater, electron-store) call
+        // `require("electron")` at top level; rolldown wraps that in
+        // a CJS-interop shim that throws under ESM, the throw turns
+        // into a GUI alert that hangs CI for ~38 min per run before
+        // failing every test at electronApp.firstWindow().
+        // CJS sidesteps the trap entirely. See lex-fmt/lexed#69.
+        //
+        // Both `lib.formats` and `lib.fileName` need to be overridden
+        // — vite-plugin-electron's default fileName is `[name].js`
+        // (which would clash with the `"type": "module"` parent and
+        // be loaded as ESM regardless of bundle format).
+        vite: {
+          build: {
+            lib: {
+              entry: 'electron/main.ts',
+              formats: ['cjs'],
+              fileName: () => '[name].cjs',
+            },
+          },
+        },
       },
       preload: {
         // Shortcut of `build.rollupOptions.input`.
         input: 'electron/preload.ts',
+        // Preload runs in the renderer's preload context; ESM is fine
+        // there and there are no problematic CJS deps to bundle. Leave
+        // it as the default (.mjs).
       },
       // Ployfill the Electron and Node.js API for Renderer process.
       // If you want use Node.js in Renderer process, the `nodeIntegration` needs to be enabled in the Main process.


### PR DESCRIPTION
Closes #69. Unblocks #68.

## Summary
- `vite-plugin-electron`'s `resolveViteConfig()` defaults `build.lib.formats` to `['es']` when `package.json` has `"type": "module"`. The bundled CJS deps (`electron-log`, `electron-updater`, `electron-store`) call `require("electron")` at top level; rolldown wraps that in a CJS-interop shim that throws under ESM. Electron's GUI-alert handler intercepts the throw before any user code runs, the alert hangs CI's xvfb display, and every test times out at `electronApp.firstWindow()` after 30s.
- This PR forces CJS for the main process bundle. Preload stays as `.mjs` (renderer preload context supports ESM, no problematic CJS deps).

## Changes
- `vite.config.ts` — drop the `/simple` shorthand for `main` and override `build.lib.formats=['cjs']` + `lib.fileName='[name].cjs'`.
- `package.json` — `"main"` → `dist-electron/main.cjs`.
- `electron/main.ts`, `electron/window-manager.ts` — drop the `fileURLToPath(import.meta.url)` ESM workaround. `import.meta.url` is undefined under CJS and threw `path argument must be of type string` immediately after the format switch — the second wave of error this PR resolves. The CJS runtime provides `__dirname` natively.

## Test plan
- [x] `rm -rf dist-electron && npx vite build && npx electron .` — window opens, LSP starts, no errors thrown.
- [x] `npm run typecheck` — clean.
- [x] `npm run test:unit` — 115/115 pass.
- [ ] CI — Build and Test should be green; E2E suite should now reach `firstWindow()` instead of timing out across the board.
- [ ] After merge: rebase #68 onto fixed main → e2e flips green automatically.

## Follow-up
Per #69's side observation, integrating [electron-splash-guard](https://github.com/arthur-debert/electron-splashguard) would surface this class of pre-init crash to `console.error` instead of a GUI alert, making future Electron migration regressions visible in CI logs. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)