### PR TITLE
fix(electron): seed cold-start file opens through persisted state

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,6 +27,7 @@ import {
 } from './file-routing'
 import {
   appendFilesToWindowPaneLayout,
+  dedupePreservingOrder,
   setWindowFolder,
   setWindowPaneLayout,
   upsertWindowState,
@@ -566,13 +567,17 @@ async function openFilesViaRouter(filePaths: string[]): Promise<FileRouteDestina
  * The renderer loads this state via `get-open-tabs` on mount — deterministic.
  */
 function seedNewWindowState(stateId: string, files: string[], root: string | null): void {
+  // Dedupe: hydration via `get-open-tabs` does not pass through the
+  // renderer's pane-level dedupe, so repeated argv entries (`lexed a a`)
+  // would otherwise materialize as duplicate tabs.
+  const tabs = dedupePreservingOrder(files)
   const paneId = randomUUID()
   const rowId = randomUUID()
   const paneLayout = [
     {
       id: paneId,
-      tabs: files,
-      activeTab: files[files.length - 1] ?? null,
+      tabs,
+      activeTab: tabs[tabs.length - 1] ?? null,
     },
   ]
   const paneRows = [{ id: rowId, paneIds: [paneId] }]
@@ -597,12 +602,20 @@ function seedNewWindowState(stateId: string, files: string[], root: string | nul
  * restored renderer picks them up via `get-open-tabs` on mount. Sister to
  * `seedNewWindowState`; safe to call alongside an `open-file-path` IPC send
  * because the renderer dedupes tabs by path.
+ *
+ * Falls back to `seedNewWindowState` semantics when the store has no entry
+ * for `stateId` yet — e.g. a brand-new window whose renderer hasn't yet
+ * pushed `set-open-tabs` — so cold-start file routing into a freshly created
+ * window still seeds the pane layout instead of relying on the racy IPC.
  */
 function seedFilesIntoExistingWindow(stateId: string, files: string[]): void {
   if (files.length === 0) return
   const openWindows = store.store.openWindows ?? []
   const idx = openWindows.findIndex((w) => w.id === stateId)
-  if (idx < 0) return
+  if (idx < 0) {
+    seedNewWindowState(stateId, files, null)
+    return
+  }
   const updated = openWindows.slice()
   updated[idx] = appendFilesToWindowPaneLayout(openWindows[idx], files)
   store.set('openWindows', updated)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,7 +25,12 @@ import {
   type OpenWindowState,
   type RecentRoot,
 } from './file-routing'
-import { setWindowFolder, setWindowPaneLayout, upsertWindowState } from './window-state'
+import {
+  appendFilesToWindowPaneLayout,
+  setWindowFolder,
+  setWindowPaneLayout,
+  upsertWindowState,
+} from './window-state'
 import { randomUUID } from 'crypto'
 
 const DEFAULT_WINDOW_BOUNDS = { width: 1200, height: 800 }
@@ -496,6 +501,15 @@ async function openFilesViaRouter(filePaths: string[]): Promise<FileRouteDestina
   for (const [windowId, files] of toExistingWindow) {
     const win = BrowserWindow.fromId(windowId)
     if (!win || win.isDestroyed()) continue
+    // Seed the files into the window's persisted pane layout. On a cold start
+    // the window may have been created by restoreWindows() but its renderer
+    // hasn't yet registered the `open-file-path` IPC listener, so the send()
+    // below would be silently dropped. Seeding first means the renderer picks
+    // up the file via `get-open-tabs` on mount; warm windows still respond to
+    // the IPC immediately, and the renderer dedupes by path so we don't
+    // double-open.
+    const stateId = windowManager.getWindowStateId(windowId)
+    if (stateId) seedFilesIntoExistingWindow(stateId, files)
     for (const file of files) {
       win.webContents.send('open-file-path', file)
       app.addRecentDocument(file)
@@ -579,6 +593,22 @@ function seedNewWindowState(stateId: string, files: string[], root: string | nul
 }
 
 /**
+ * Seed `files` into an already-persisted window's pane layout so a freshly
+ * restored renderer picks them up via `get-open-tabs` on mount. Sister to
+ * `seedNewWindowState`; safe to call alongside an `open-file-path` IPC send
+ * because the renderer dedupes tabs by path.
+ */
+function seedFilesIntoExistingWindow(stateId: string, files: string[]): void {
+  if (files.length === 0) return
+  const openWindows = store.store.openWindows ?? []
+  const idx = openWindows.findIndex((w) => w.id === stateId)
+  if (idx < 0) return
+  const updated = openWindows.slice()
+  updated[idx] = appendFilesToWindowPaneLayout(openWindows[idx], files)
+  store.set('openWindows', updated)
+}
+
+/**
  * Open paths from CLI arguments.
  * Handles both files and folders.
  */
@@ -596,7 +626,12 @@ function openCliPaths(cliPaths: CliPaths) {
     if (folder) {
       targetWin.webContents.send('open-folder-path', folder)
     }
-    // Then open files
+    // Then open files (seed first so a still-loading renderer picks them up
+    // via `get-open-tabs`; warm windows respond to the IPC immediately).
+    if (files.length > 0) {
+      const stateId = windowManager.getWindowStateId(targetWin.id)
+      if (stateId) seedFilesIntoExistingWindow(stateId, files)
+    }
     for (const filePath of files) {
       targetWin.webContents.send('open-file-path', filePath)
       app.addRecentDocument(filePath)
@@ -604,12 +639,24 @@ function openCliPaths(cliPaths: CliPaths) {
     // Bring window to front
     restoreAndFocus(targetWin)
   } else {
-    // No windows exist, create a new one
-    // The folder will be set via settings if provided
+    // No windows exist, create a new one with files seeded into its
+    // persisted state — `did-finish-load → send` is racy on cold start.
     if (folder) {
       store.set('lastFolder', folder)
     }
-    windowManager.createWindow(undefined, { showSplash: true, openFiles: files })
+    const newStateId = randomUUID()
+    if (files.length > 0) {
+      seedNewWindowState(newStateId, files, folder ?? null)
+    }
+    windowManager.createWindow(
+      {
+        id: newStateId,
+        width: DEFAULT_WINDOW_BOUNDS.width,
+        height: DEFAULT_WINDOW_BOUNDS.height,
+        ...(folder ? { lastFolder: folder } : {}),
+      },
+      { showSplash: true }
+    )
   }
 }
 
@@ -1774,21 +1821,45 @@ if (!gotTheLock) {
     // Handle first launch setup (create Documents/LexEd and copy welcome doc)
     const welcomeFilePath = await setupFirstLaunch()
 
-    // Handle paths passed via command line on initial launch (CLI support)
+    // Handle paths passed via command line on initial launch (CLI support).
+    // Files are seeded into the window's persisted state so the renderer picks
+    // them up via `get-open-tabs` on mount — `did-finish-load → send` is racy
+    // on cold start.
     const cliPaths = extractPathsFromArgv(process.argv)
     if (cliPaths.files.length > 0 || cliPaths.folder) {
-      // CLI invocation with paths
       if (cliPaths.folder) {
         store.set('lastFolder', cliPaths.folder)
         recordRecentRoot(cliPaths.folder)
       }
-      windowManager.createWindow(undefined, { showSplash: true, openFiles: cliPaths.files })
+      const newStateId = randomUUID()
+      if (cliPaths.files.length > 0) {
+        seedNewWindowState(newStateId, cliPaths.files, cliPaths.folder ?? null)
+      }
+      windowManager.createWindow(
+        {
+          id: newStateId,
+          width: DEFAULT_WINDOW_BOUNDS.width,
+          height: DEFAULT_WINDOW_BOUNDS.height,
+          ...(cliPaths.folder ? { lastFolder: cliPaths.folder } : {}),
+        },
+        { showSplash: true }
+      )
     } else if (welcomeFilePath) {
       // First launch: set the LexEd folder as workspace and open welcome file
       const projectPath = getDefaultProjectPath()
       store.set('lastFolder', projectPath)
       recordRecentRoot(projectPath)
-      windowManager.createWindow(undefined, { showSplash: true, openFiles: [welcomeFilePath] })
+      const newStateId = randomUUID()
+      seedNewWindowState(newStateId, [welcomeFilePath], projectPath)
+      windowManager.createWindow(
+        {
+          id: newStateId,
+          width: DEFAULT_WINDOW_BOUNDS.width,
+          height: DEFAULT_WINDOW_BOUNDS.height,
+          lastFolder: projectPath,
+        },
+        { showSplash: true }
+      )
     } else {
       windowManager.restoreWindows()
     }

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -242,10 +242,7 @@ export class WindowManager {
     win.setTitle(title)
   }
 
-  public async createWindow(
-    restoreState?: WindowState,
-    options?: { showSplash?: boolean; openFiles?: string[] }
-  ) {
+  public async createWindow(restoreState?: WindowState, options?: { showSplash?: boolean }) {
     const hideWindow = process.env.E2E_HIDE_WINDOW === '1'
     const stateId = restoreState?.id || randomUUID()
     const showSplash = options?.showSplash && !hideWindow
@@ -336,15 +333,6 @@ export class WindowManager {
         win.loadURL(VITE_DEV_SERVER_URL)
       } else {
         win.loadFile(path.join(RENDERER_DIST, 'index.html'))
-      }
-
-      // If files need to be opened, send them after the renderer is ready
-      if (options?.openFiles && options.openFiles.length > 0) {
-        win.webContents.once('did-finish-load', () => {
-          for (const filePath of options.openFiles!) {
-            win.webContents.send('open-file-path', filePath)
-          }
-        })
       }
 
       return win

--- a/electron/window-state.test.ts
+++ b/electron/window-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  appendFilesToWindowPaneLayout,
   upsertWindowState,
   mergeBounds,
   setWindowFolder,
@@ -196,5 +197,123 @@ describe('setWindowPaneLayout', () => {
     expect(result[0].lastFolder).toBe('/docs')
     expect(result[0].paneLayout?.[0].id).toBe('new')
     expect(result[0].activePaneId).toBe('new')
+  })
+})
+
+describe('appendFilesToWindowPaneLayout', () => {
+  const baseState = (): WindowState => ({
+    id: 'abc',
+    width: 1200,
+    height: 800,
+    lastFolder: '/docs',
+  })
+
+  it('returns the state unchanged when given no files', () => {
+    const state = baseState()
+    expect(appendFilesToWindowPaneLayout(state, [])).toBe(state)
+  })
+
+  it('creates a fresh pane + row when state has no paneLayout', () => {
+    const result = appendFilesToWindowPaneLayout(baseState(), ['/docs/a.lex', '/docs/b.lex'])
+    expect(result.paneLayout).toHaveLength(1)
+    expect(result.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
+    expect(result.paneLayout?.[0].activeTab).toBe('/docs/b.lex')
+    expect(result.paneRows).toHaveLength(1)
+    expect(result.paneRows?.[0].paneIds).toEqual([result.paneLayout![0].id])
+    expect(result.activePaneId).toBe(result.paneLayout![0].id)
+    expect(result.lastFolder).toBe('/docs')
+  })
+
+  it('appends to the active pane and updates activeTab', () => {
+    const state: WindowState = {
+      ...baseState(),
+      paneLayout: [
+        { id: 'p1', tabs: ['/docs/old.lex'], activeTab: '/docs/old.lex' },
+        { id: 'p2', tabs: [], activeTab: null },
+      ],
+      paneRows: [{ id: 'r1', paneIds: ['p1', 'p2'] }],
+      activePaneId: 'p1',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/docs/new.lex'])
+    expect(result.paneLayout?.[0].tabs).toEqual(['/docs/old.lex', '/docs/new.lex'])
+    expect(result.paneLayout?.[0].activeTab).toBe('/docs/new.lex')
+    expect(result.paneLayout?.[1]).toEqual({ id: 'p2', tabs: [], activeTab: null })
+    expect(result.activePaneId).toBe('p1')
+  })
+
+  it('falls back to the first pane when activePaneId is missing or stale', () => {
+    const state: WindowState = {
+      ...baseState(),
+      paneLayout: [{ id: 'p1', tabs: ['/docs/old.lex'], activeTab: '/docs/old.lex' }],
+      paneRows: [{ id: 'r1', paneIds: ['p1'] }],
+      activePaneId: 'gone',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/docs/new.lex'])
+    expect(result.paneLayout?.[0].tabs).toEqual(['/docs/old.lex', '/docs/new.lex'])
+    expect(result.activePaneId).toBe('p1')
+  })
+
+  it('deduplicates already-present tabs but still updates activeTab', () => {
+    const state: WindowState = {
+      ...baseState(),
+      paneLayout: [{ id: 'p1', tabs: ['/docs/a.lex', '/docs/b.lex'], activeTab: '/docs/a.lex' }],
+      paneRows: [{ id: 'r1', paneIds: ['p1'] }],
+      activePaneId: 'p1',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/docs/b.lex'])
+    expect(result.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
+    expect(result.paneLayout?.[0].activeTab).toBe('/docs/b.lex')
+  })
+
+  it('is idempotent under repeated seeding of the same files', () => {
+    const start: WindowState = baseState()
+    const once = appendFilesToWindowPaneLayout(start, ['/docs/a.lex', '/docs/b.lex'])
+    const twice = appendFilesToWindowPaneLayout(once, ['/docs/a.lex', '/docs/b.lex'])
+    expect(twice.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
+    expect(twice.paneLayout?.[0].activeTab).toBe('/docs/b.lex')
+    expect(twice.paneLayout?.[0].id).toBe(once.paneLayout?.[0].id)
+  })
+
+  it('inserts a row covering the target pane when none exists', () => {
+    const state: WindowState = {
+      ...baseState(),
+      paneLayout: [{ id: 'p1', tabs: [], activeTab: null }],
+      paneRows: [],
+      activePaneId: 'p1',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/docs/a.lex'])
+    expect(result.paneRows).toHaveLength(1)
+    expect(result.paneRows?.[0].paneIds).toContain('p1')
+  })
+
+  it('does not duplicate row coverage when a row already includes the target pane', () => {
+    const state: WindowState = {
+      ...baseState(),
+      paneLayout: [{ id: 'p1', tabs: [], activeTab: null }],
+      paneRows: [{ id: 'r1', paneIds: ['p1'] }],
+      activePaneId: 'p1',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/docs/a.lex'])
+    expect(result.paneRows).toHaveLength(1)
+    expect(result.paneRows?.[0].id).toBe('r1')
+  })
+
+  it('preserves untouched fields like lastFolder and bounds', () => {
+    const state: WindowState = {
+      id: 'abc',
+      x: 100,
+      y: 200,
+      width: 1024,
+      height: 768,
+      isMaximized: true,
+      lastFolder: '/projects/x',
+    }
+    const result = appendFilesToWindowPaneLayout(state, ['/projects/x/a.lex'])
+    expect(result.x).toBe(100)
+    expect(result.y).toBe(200)
+    expect(result.width).toBe(1024)
+    expect(result.height).toBe(768)
+    expect(result.isMaximized).toBe(true)
+    expect(result.lastFolder).toBe('/projects/x')
   })
 })

--- a/electron/window-state.test.ts
+++ b/electron/window-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   appendFilesToWindowPaneLayout,
+  dedupePreservingOrder,
   upsertWindowState,
   mergeBounds,
   setWindowFolder,
@@ -224,6 +225,16 @@ describe('appendFilesToWindowPaneLayout', () => {
     expect(result.lastFolder).toBe('/docs')
   })
 
+  it('dedupes duplicate paths within a single seed for a fresh layout', () => {
+    const result = appendFilesToWindowPaneLayout(baseState(), [
+      '/docs/a.lex',
+      '/docs/a.lex',
+      '/docs/b.lex',
+    ])
+    expect(result.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
+    expect(result.paneLayout?.[0].activeTab).toBe('/docs/b.lex')
+  })
+
   it('appends to the active pane and updates activeTab', () => {
     const state: WindowState = {
       ...baseState(),
@@ -315,5 +326,19 @@ describe('appendFilesToWindowPaneLayout', () => {
     expect(result.height).toBe(768)
     expect(result.isMaximized).toBe(true)
     expect(result.lastFolder).toBe('/projects/x')
+  })
+})
+
+describe('dedupePreservingOrder', () => {
+  it('returns an empty array unchanged', () => {
+    expect(dedupePreservingOrder([])).toEqual([])
+  })
+
+  it('preserves first occurrence and drops later duplicates', () => {
+    expect(dedupePreservingOrder(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns an array with all unique items unchanged', () => {
+    expect(dedupePreservingOrder(['x', 'y', 'z'])).toEqual(['x', 'y', 'z'])
   })
 })

--- a/electron/window-state.ts
+++ b/electron/window-state.ts
@@ -115,7 +115,7 @@ export function setWindowPaneLayout(
  * Used by the file router to seed an existing window's state before the
  * renderer has finished mounting on a cold start. Without this, the
  * `open-file-path` IPC fires before the renderer registers its listener and
- * the file is silently dropped (see lexed#? — Finder cold-open regression).
+ * the file is silently dropped (Finder cold-open regression).
  *
  * Idempotent: re-seeding the same files only updates `activeTab`.
  */
@@ -173,7 +173,7 @@ export function appendFilesToWindowPaneLayout(state: WindowState, files: string[
   }
 }
 
-function dedupePreservingOrder(items: string[]): string[] {
+export function dedupePreservingOrder(items: string[]): string[] {
   const seen = new Set<string>()
   const out: string[] = []
   for (const item of items) {

--- a/electron/window-state.ts
+++ b/electron/window-state.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { PaneLayoutSettings, PaneRowLayout, WindowState } from './window-manager'
 
 /**
@@ -105,4 +106,81 @@ export function setWindowPaneLayout(
       activePaneId,
     }
   )
+}
+
+/**
+ * Append `files` to the persisted pane layout for `state`, deduplicating tabs
+ * by path and keeping the last requested file as the active tab.
+ *
+ * Used by the file router to seed an existing window's state before the
+ * renderer has finished mounting on a cold start. Without this, the
+ * `open-file-path` IPC fires before the renderer registers its listener and
+ * the file is silently dropped (see lexed#? — Finder cold-open regression).
+ *
+ * Idempotent: re-seeding the same files only updates `activeTab`.
+ */
+export function appendFilesToWindowPaneLayout(state: WindowState, files: string[]): WindowState {
+  if (files.length === 0) return state
+
+  const existingPanes = state.paneLayout ?? []
+  const existingRows = state.paneRows ?? []
+
+  if (existingPanes.length === 0) {
+    const paneId = randomUUID()
+    const rowId = randomUUID()
+    return {
+      ...state,
+      paneLayout: [
+        {
+          id: paneId,
+          tabs: dedupePreservingOrder(files),
+          activeTab: files[files.length - 1] ?? null,
+        },
+      ],
+      paneRows: [{ id: rowId, paneIds: [paneId] }],
+      activePaneId: paneId,
+    }
+  }
+
+  const targetPaneId =
+    state.activePaneId && existingPanes.some((p) => p.id === state.activePaneId)
+      ? state.activePaneId
+      : existingPanes[0].id
+
+  const newPanes: PaneLayoutSettings[] = existingPanes.map((pane) => {
+    if (pane.id !== targetPaneId) return pane
+    const seen = new Set(pane.tabs)
+    const tabs = pane.tabs.slice()
+    for (const f of files) {
+      if (!seen.has(f)) {
+        tabs.push(f)
+        seen.add(f)
+      }
+    }
+    return { ...pane, tabs, activeTab: files[files.length - 1] }
+  })
+
+  const rowsCoverTarget = existingRows.some((row) => row.paneIds.includes(targetPaneId))
+  const newRows: PaneRowLayout[] = rowsCoverTarget
+    ? existingRows
+    : [{ id: randomUUID(), paneIds: [targetPaneId] }, ...existingRows]
+
+  return {
+    ...state,
+    paneLayout: newPanes,
+    paneRows: newRows,
+    activePaneId: targetPaneId,
+  }
+}
+
+function dedupePreservingOrder(items: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const item of items) {
+    if (!seen.has(item)) {
+      seen.add(item)
+      out.push(item)
+    }
+  }
+  return out
 }

--- a/tests/e2e/file-routing.spec.ts
+++ b/tests/e2e/file-routing.spec.ts
@@ -154,6 +154,46 @@ test.describe('File routing & workspace persistence', () => {
     }
   })
 
+  test("seeds the file into the existing window's persisted paneLayout (cold-start safe)", async () => {
+    // Regression: on a macOS Finder cold-open, the routed file's
+    // `open-file-path` IPC could fire before the renderer registered its
+    // listener, so the file was silently dropped. The fix is to also seed the
+    // file into the window's persisted state — verified here by reading
+    // openWindows from the store after routing.
+    const workspace = mkTmp('lexed-ws-')
+    try {
+      const filePath = path.join(workspace, 'cold.lex')
+      fs.writeFileSync(filePath, 'content')
+
+      const { app, page } = await launchReady(userData)
+      await setWorkspace(page, workspace)
+
+      const result = await page.evaluate(async (fp) => {
+        return window.ipcRenderer.testRouteOpenFiles([fp])
+      }, filePath)
+      expect(result[0].kind).toBe('existingWindow')
+
+      // The seed lands on the persisted state synchronously inside the router;
+      // the renderer's own auto-save may also fire, but either way the file
+      // must end up in paneLayout.
+      await page.waitForFunction(
+        async (expected) => {
+          const settings = await window.ipcRenderer.getAppSettings()
+          const tabs = settings.openWindows?.[0]?.paneLayout?.flatMap(
+            (p: { tabs: string[] }) => p.tabs
+          )
+          return tabs?.includes(expected) ?? false
+        },
+        filePath,
+        { timeout: 5000 }
+      )
+
+      await app.close()
+    } finally {
+      rmrf(workspace)
+    }
+  })
+
   test('OS-opens a file under a recent (non-current) root in a new window with that root', async () => {
     const workspaceA = mkTmp('lexed-wsA-')
     const workspaceB = mkTmp('lexed-wsB-')


### PR DESCRIPTION
## Summary

When LexEd is the macOS default handler for `.lex` files and the user double-clicks a file in Finder while LexEd isn't running, the file silently fails to appear. Quitting and reopening usually shows the file the second time. The bug is a known race that was only partially fixed: the OS `open-file` event was queued, restored windows came up, the queue drained into an `open-file-path` IPC send, and that IPC fired before the renderer registered its listener — so the message dropped. Warm OS/disk caches usually let the second cold-start win the race.

`seedNewWindowState` already implemented the deterministic alternative (write `paneLayout` to the persisted store, renderer hydrates via `get-open-tabs` on mount) — but only the `newWindow` and `newWindowWithRoot` branches of `routeOpenFile` used it. The `existingWindow` branch (the one cold-restored windows hit) and the Windows/Linux cold-start paths (`createWindow({ openFiles })` → racy `did-finish-load → send`) still relied on raw IPC.

This PR routes every cold-start file open through the seed pattern.

## Changes

- **`window-state.ts`** — pure `appendFilesToWindowPaneLayout(state, files)`: appends to active pane (or first), creates a fresh pane + row if none, dedupes by path, promotes the last requested file to `activeTab`.
- **`main.ts`** — new `seedFilesIntoExistingWindow(stateId, files)` wrapper called from the `existingWindow` route in `openFilesViaRouter` and from `openCliPaths`'s warm-window branch, alongside the existing IPC send. Renderer's `openFileInPane` already dedupes by path, so warm and cold paths can't double-open.
- **`main.ts`** — three `createWindow(undefined, { openFiles })` call sites (CLI launch, welcome, no-window CLI) replaced with `seedNewWindowState` + `createWindow({ id, ... })`.
- **`window-manager.ts`** — drops the unused `openFiles` option and the racy `did-finish-load → send` block.

## Tests

- 9 new unit tests for `appendFilesToWindowPaneLayout`: empty input, fresh layout, active-pane append, stale `activePaneId` fallback, dedupe + activeTab semantics, idempotence, row coverage, preservation of unrelated `WindowState` fields.
- New e2e regression test (`file-routing.spec.ts`) — asserts the file lands in the persisted `paneLayout` after `existingWindow` routing, so a cold-start renderer would pick it up via `get-open-tabs`.
- 124 unit + 42 e2e (dev + packaged) all pass locally.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:unit` (124 pass)
- [x] `E2E_USE_BUILD=1 E2E_SKIP_BUILD=1 npx playwright test tests/e2e` (39 dev + 3 packaged, 42 pass)
- [ ] Manual smoke: set LexEd as default `.lex` handler, quit, double-click a `.lex` outside the last workspace root in Finder. Expected: file opens on first try.
- [ ] Manual smoke: relaunch LexEd from CLI (`lexed /path/to/file.lex`). Expected: file is open in the new window's tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)