### PR TITLE
release: v0.8.0 — lexd-lsp v0.10.0 + comms v0.16.0 (includes feature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.8.0 (2026-05-04)
+
+### Changed
+
+- Bumped `lexd-lsp` pin from v0.8.8 to v0.10.0. Adds the `lex.include` annotation surface in the editor: real-time include diagnostics (broken paths, cycles, depth-exceeded, root-escape, container-policy violations, etc.) on every edit, goto-definition that jumps from `:: lex.include src="chapter.lex" ::` into the target file, and a hover preview that shows the resolved path plus the first non-blank lines of the target. No editor-side configuration required — the LSP handles include resolution from the host's `[includes]` config (with sensible defaults).
+- Bumped `comms` submodule to v0.16.0 (canonical `lex.include` element doc + fixture set + formal reservation of the `lex.*` annotation namespace).
+
 ## v0.7.1 (2026-05-02)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexed",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexed",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@lex/monaco-inline-injections": "file:./packages/monaco-inline-injections",
         "@lex/shared": "file:./shared",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lexed",
   "productName": "LexEd",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "LexEd editor for Lex",
   "author": {
     "name": "Arthur Debert",

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -88,7 +88,12 @@ download_dep() {
   fi
   popd >/dev/null
 
-  if [[ ! -f "$tmp_dir/$binary_name" ]]; then
+  # arthur-debert/release@v1 (lex v0.10.0+) nests the binary under
+  # <name>-<target>/; earlier releases had it at the top level. Locate
+  # by name to handle both layouts.
+  local binary_src
+  binary_src="$(find "$tmp_dir" -name "$binary_name" -type f | head -1)"
+  if [[ -z "$binary_src" ]]; then
     echo "Binary $binary_name not found in archive" >&2
     rm -rf "$tmp_dir"
     exit 1
@@ -96,7 +101,7 @@ download_dep() {
 
   local dest="$RESOURCES_DIR/$dep"
   $is_windows && dest="${dest}.exe"
-  cp "$tmp_dir/$binary_name" "$dest"
+  cp "$binary_src" "$dest"
   chmod +x "$dest"
   rm -rf "$tmp_dir"
 

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.8.8",
+      "version": "v0.10.0",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {


### PR DESCRIPTION
## Summary

Cuts lexed v0.8.0:
- Bumps `shared/lex-deps.json` `lexd-lsp` v0.8.8 → v0.10.0
- Bumps `comms` submodule v0.15.0 → v0.16.0
- Bumps `package.json` and `package-lock.json` to 0.8.0
- Rolls v0.8.0 entry to top of `CHANGELOG.md`
- Fixes `scripts/fetch-deps.sh` to handle the new arthur-debert/release@v1 tarball layout (binary nested under `<name>-<target>/` in v0.10.0+; was at top level pre-v0.10.0). Locates by name to support both layouts.

## What users get

The `lex.include` annotation surface is now live in lexed:
- Real-time include diagnostics (broken paths, cycles, depth-exceeded, root-escape, container-policy)
- Goto-definition jumps from `:: lex.include src="chapter.lex" ::` into the target file
- Hover preview shows the resolved path + first non-blank lines of the target

No editor-side code changes — the LSP handles end-to-end resolution.

## Test plan

- [x] Pre-commit checks (fmt + lint + type-check + 42 E2E tests including bundled lexd-lsp init) green locally
- [ ] CI green