### PR TITLE
ci(release): force UTF-8 in Python scripts on Windows runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+      # Force UTF-8 stdout/stderr in Python scripts. Default cp1252 on
+      # Windows runners can't encode characters like '✓' that some build
+      # scripts emit (e.g. gen-theme.py status output).
+      PYTHONUTF8: '1'
     steps:
       - name: Evaluate target filter
         id: target-filter


### PR DESCRIPTION
## Summary

Sets `PYTHONUTF8=1` on the build job so Python scripts emit UTF-8 stdout regardless of host locale. Default Windows runners use `cp1252` which can't encode `'✓'` (U+2713) — `gen-theme.py` (or similar) was tripping a `UnicodeEncodeError` on Windows, killing the windows-x64 artifact in the v0.8.0 release.

After merge: delete the existing `v0.8.0` tag + release object and re-tag main to trigger a clean build.

## Test plan

- [x] Pre-commit (E2E + 42 tests) green locally
- [ ] CI green
- [ ] Re-tagged v0.8.0 release CI completes with the windows-x64 .exe artifact present