### PR TITLE
chore: bump lexd-lsp pin to v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Bumped `lexd-lsp` pin from v0.10.0 to v0.10.5. Headline fixes for the
+  document-link surface that Monaco renders as the clickable region for
+  `[bracketed]` references:
+  - The link range is now scoped to the bracketed reference itself; a
+    paragraph containing a URL or file reference no longer renders end-to-end
+    as one clickable link.
+  - References that appear in a section heading (e.g.
+    `1. See [./handlers.lex] for details`) now also contribute clickable
+    links — previously the LSP silently dropped them from the
+    `documentLink` response.
+- Also includes everything else from v0.10.1 through v0.10.5: the
+  `include-not-found` diagnostic now points at the offending
+  `lex.include` annotation instead of the document head, and `FsLoader`
+  picked up symlink-traversal defenses, resource limits
+  (`max_total_includes`, `max_file_size`), and rejection of
+  platform-absolute include paths.
+
 ## v0.8.0 (2026-05-04)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@
   `lex.include` annotation instead of the document head, and `FsLoader`
   picked up symlink-traversal defenses, resource limits
   (`max_total_includes`, `max_file_size`), and rejection of
-  platform-absolute include paths.
+  platform-absolute include paths. The absolute-path rejection is a
+  behavior change for documents that contained
+  `:: lex.include src="C:\path\to\file" ::` style annotations — those
+  now error up front with a clear "absolute path not allowed" message
+  via `IncludeError::AbsolutePath` instead of being caught downstream
+  by the root-escape check with a misleading error. The supported
+  forms are unchanged (relative paths and root-absolute `/path` against
+  the configured includes root).
 
 ## v0.8.0 (2026-05-04)
 

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.10.0",
+      "version": "v0.10.5",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {


### PR DESCRIPTION
## Summary

Bumps the `lexd-lsp` pin in `shared/lex-deps.json` from `v0.10.0` to `v0.10.5`. Same headline fixes as the vscode bump (PR pending in lex-fmt/vscode): documentLink ranges scoped to `[bracketed]` instead of paragraph/title, and section-heading references now produce clickable links. Plus the v0.10.1–v0.10.5 carry-over.

User-visible impact in lexed: in Monaco's editor view, the clickable region on a `[bracketed]` reference now stops at the brackets instead of spanning the whole paragraph or section heading.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — `CHANGELOG.md` Unreleased section populated
- [x] Project umbrella check passes locally — pin is a fetch-time concern, no source changes
- [x] Tests added or updated for behavior changes — N/A (pin bump)

## Notes for reviewers

- After this merges, the release flow is: bump `package.json` 0.8.0 → 0.8.1, replace `## Unreleased` with `## v0.8.1 (2026-05-07)` in `CHANGELOG.md`, commit, tag `v0.8.1`, push — release.yml fires on `v*` tag push and builds the platform binaries.