### PR TITLE
chore: bump lexd-lsp v0.11.0 + add trust-prompt e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@
 - `@lex-fmt/lex-buffer`: `LspClient` gains `onRequest(method, handler)`
   for registering server→client custom request handlers (mirror of the
   existing `onNotification`). Used by the trust-prompt wiring above.
+- Bumped `lexd-lsp` pin from v0.10.6 to v0.11.0. Picks up the
+  extension dispatch + trust-prompt forwarding + boot-serialization
+  wiring this app's trust-prompt handler depends on. See lex-fmt/lex
+  CHANGELOG `[0.11.0]` for the full surface.
+
+### Tests
+
+- New Playwright e2e spec (`tests/e2e/trust-prompt.spec.ts`) covering
+  the `lex/trustRequest` modal end-to-end via the e2e bridge:
+  injects a fake trust request through `window.__e2e.bridge.injectTrustRequest`,
+  asserts the modal renders with the namespace, command, and
+  capability labels visible, and verifies clicking Trust → trusted,
+  Deny → denied with a named reason, Esc → denied + dismissed
+  (fail-closed). The bridge helper is added to `useLexTestBridge`.
 
 ## v0.8.2 (2026-05-07)
 

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.10.6",
+      "version": "v0.11.0",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {

--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -3,7 +3,8 @@ import * as monaco from 'monaco-editor'
 import type { EditorPaneHandle } from '@/components/EditorPane'
 import type { PaneState } from '@/panes/types'
 import { spellcheckService } from '@/spellcheck/service'
-import { lspClient } from '@lex-fmt/lex-buffer'
+import { lspClient, type TrustRequestParams } from '@lex-fmt/lex-buffer'
+import { trustPromptCoordinator } from '@/lsp/trustPromptCoordinator'
 
 type FormattingRequestPayload = {
   type: 'document' | 'range'
@@ -163,6 +164,17 @@ export function useLexTestBridge({
       openFolder: async (folderPath: string) => {
         setRootPath(folderPath)
         await window.ipcRenderer.setLastFolder(folderPath)
+      },
+
+      // Trust-prompt e2e helpers: inject a `lex/trustRequest` directly
+      // into the coordinator so e2e tests can render the modal,
+      // observe its content, and click Trust/Deny without setting up
+      // a real lexd-lsp + workspace fixture. The full LSP-fires-
+      // request path is exercised in lex-fmt/vscode#68 against a
+      // real lexd-lsp v0.11.0 binary.
+      injectTrustRequest: async (params: TrustRequestParams) => {
+        const response = await trustPromptCoordinator.request(params)
+        return response
       },
 
       // Raw LSP request helpers — mainly for e2e tests that want to

--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -172,6 +172,16 @@ export function useLexTestBridge({
       // a real lexd-lsp + workspace fixture. The full LSP-fires-
       // request path is exercised in lex-fmt/vscode#68 against a
       // real lexd-lsp v0.11.0 binary.
+      //
+      // Exposure note: this method follows the same gating as the
+      // rest of the bridge (gated only on `loadTestFixture` being
+      // present in the preload, which is unconditional today). The
+      // bridge already exposes other test-only hooks
+      // (triggerMockDiagnostics, setActiveEditorValue, etc.) under
+      // the same gate, so adding env-flag gating just for this
+      // method would be inconsistent. Tightening the whole bridge
+      // behind an explicit E2E flag is a separate refactor; tracked
+      // implicitly with the rest of the test-bridge surface.
       injectTrustRequest: async (params: TrustRequestParams) => {
         const response = await trustPromptCoordinator.request(params)
         return response

--- a/tests/e2e/trust-prompt.spec.ts
+++ b/tests/e2e/trust-prompt.spec.ts
@@ -86,6 +86,16 @@ test.describe('lex/trustRequest modal', () => {
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
       timeout: 5000,
     })
+    // Poll for the .then() callback to have populated __trustResp.
+    // The microtask scheduling of Promise resolution doesn't
+    // guarantee __trustResp is set the instant the modal disappears,
+    // so we wait for the global to populate before asserting.
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Window & { __trustResp?: TrustResponse }).__trustResp !== undefined,
+      null,
+      { timeout: 5000 }
+    )
     const response = await page.evaluate(() => {
       const w = window as unknown as Window & { __trustResp?: TrustResponse }
       return w.__trustResp
@@ -110,6 +120,12 @@ test.describe('lex/trustRequest modal', () => {
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
       timeout: 5000,
     })
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Window & { __trustResp?: TrustResponse }).__trustResp !== undefined,
+      null,
+      { timeout: 5000 }
+    )
     const response = await page.evaluate(() => {
       const w = window as unknown as Window & { __trustResp?: TrustResponse }
       return w.__trustResp
@@ -138,6 +154,12 @@ test.describe('lex/trustRequest modal', () => {
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
       timeout: 5000,
     })
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Window & { __trustResp?: TrustResponse }).__trustResp !== undefined,
+      null,
+      { timeout: 5000 }
+    )
     const response = await page.evaluate(() => {
       const w = window as unknown as Window & { __trustResp?: TrustResponse }
       return w.__trustResp

--- a/tests/e2e/trust-prompt.spec.ts
+++ b/tests/e2e/trust-prompt.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from './lib'
+import { openFixture } from './helpers'
+
+interface TrustRequestParams {
+  namespace: string
+  command_string: string
+  source: { kind: string; name?: string; path?: string; uri?: string }
+  capability: string
+  transport: string
+}
+
+interface TrustResponse {
+  decision: string
+  reason?: string
+}
+
+declare global {
+  interface Window {
+    __e2e: {
+      bridge: {
+        injectTrustRequest?: (params: TrustRequestParams) => Promise<TrustResponse>
+      } & Record<string, unknown>
+    } & Record<string, unknown>
+  }
+}
+
+const sampleParams: TrustRequestParams = {
+  namespace: 'acme',
+  command_string: '/usr/local/bin/acme-handler --serve',
+  source: { kind: 'lex_toml', name: 'acme' },
+  capability: 'full',
+  transport: 'subprocess',
+}
+
+test.describe('lex/trustRequest modal', () => {
+  test('renders the prompt with namespace + command + capability', async ({ page }) => {
+    // Open any fixture so the app is past initial load. The trust
+    // prompt itself is decoupled from any open file — it fires when
+    // the LSP sees a [labels] block during boot. We're injecting
+    // directly via the e2e bridge to avoid the workspace setup
+    // overhead; the wire-shape correctness is what matters here.
+    await openFixture(page, 'empty.lex')
+
+    // Inject a trust request and wait for the modal to render. Don't
+    // await the resolved Promise here — that resolves only after
+    // the user clicks. We just wait for the modal to appear.
+    await page.evaluate(async (params) => {
+      // Fire and forget — the Promise will resolve when the modal
+      // is closed, which we'll do via the click handler in the
+      // next part of the test.
+      void window.__e2e.bridge.injectTrustRequest!(params)
+    }, sampleParams)
+
+    // Modal title comes from <TrustPromptModal />.
+    await expect(page.getByText('Lex extension trust required')).toBeVisible({ timeout: 5000 })
+    // Headline names the namespace + transport.
+    await expect(page.getByText(/"acme".*subprocess handler/)).toBeVisible()
+    // Detail rows: source label includes lex.toml + the namespace name.
+    await expect(page.getByText('lex.toml [labels] entry "acme"')).toBeVisible()
+    // Command string in the dl.
+    await expect(page.getByText('/usr/local/bin/acme-handler --serve')).toBeVisible()
+    // Capability label for "full".
+    await expect(page.getByText(/fs and\/or net access/)).toBeVisible()
+    // Action buttons.
+    await expect(page.getByRole('button', { name: 'Trust' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Deny' })).toBeVisible()
+  })
+
+  test('clicking Trust resolves the request with decision: trusted', async ({ page }) => {
+    await openFixture(page, 'empty.lex')
+    // Race-free pattern: kick off the injection in the renderer and
+    // capture the resolved response on a global so we can read it
+    // back via page.evaluate after clicking.
+    await page.evaluate((params) => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      w.__trustResp = undefined
+      void window.__e2e.bridge.injectTrustRequest!(params).then((resp) => {
+        w.__trustResp = resp
+      })
+    }, sampleParams)
+
+    await expect(page.getByText('Lex extension trust required')).toBeVisible({ timeout: 5000 })
+    await page.getByRole('button', { name: 'Trust' }).click()
+
+    // Modal closes after the click resolves the Promise.
+    await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
+      timeout: 5000,
+    })
+    const response = await page.evaluate(() => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      return w.__trustResp
+    })
+    expect(response?.decision).toBe('trusted')
+    expect(response?.reason).toBeUndefined()
+  })
+
+  test('clicking Deny resolves with decision: denied + named reason', async ({ page }) => {
+    await openFixture(page, 'empty.lex')
+    await page.evaluate((params) => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      w.__trustResp = undefined
+      void window.__e2e.bridge.injectTrustRequest!(params).then((resp) => {
+        w.__trustResp = resp
+      })
+    }, sampleParams)
+
+    await expect(page.getByText('Lex extension trust required')).toBeVisible({ timeout: 5000 })
+    await page.getByRole('button', { name: 'Deny' }).click()
+
+    await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
+      timeout: 5000,
+    })
+    const response = await page.evaluate(() => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      return w.__trustResp
+    })
+    expect(response?.decision).toBe('denied')
+    expect(response?.reason).toContain('acme')
+    expect(response?.reason).toContain('denied trust')
+  })
+
+  test('Esc dismisses with denied + dismissed reason (fail-closed)', async ({ page }) => {
+    // Esc handler is wired in TrustPromptModal — Copilot caught
+    // this missing in PR #86's review. Verifying it actually works
+    // end-to-end keeps the regression guard tight.
+    await openFixture(page, 'empty.lex')
+    await page.evaluate((params) => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      w.__trustResp = undefined
+      void window.__e2e.bridge.injectTrustRequest!(params).then((resp) => {
+        w.__trustResp = resp
+      })
+    }, sampleParams)
+
+    await expect(page.getByText('Lex extension trust required')).toBeVisible({ timeout: 5000 })
+    await page.keyboard.press('Escape')
+
+    await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
+      timeout: 5000,
+    })
+    const response = await page.evaluate(() => {
+      const w = window as unknown as Window & { __trustResp?: TrustResponse }
+      return w.__trustResp
+    })
+    expect(response?.decision).toBe('denied')
+    expect(response?.reason).toContain('dismissed')
+  })
+})


### PR DESCRIPTION
Follow-up to [#86](https://github.com/lex-fmt/lexed/pull/86), pinning the new \`lexd-lsp\` v0.11.0 release and adding a Playwright e2e covering the trust-prompt modal end-to-end.

## What changed

- \`shared/lex-deps.json\` lexd-lsp pin v0.10.6 → v0.11.0.
- \`src/hooks/useLexTestBridge.ts\` gains \`injectTrustRequest(params): Promise<TrustResponse>\` on the e2e bridge — forwards to \`trustPromptCoordinator.request()\`.
- New Playwright spec \`tests/e2e/trust-prompt.spec.ts\` covering:
    - "renders the prompt with namespace + command + capability"
    - "clicking Trust resolves the request with decision: trusted"
    - "clicking Deny resolves with decision: denied + named reason"
    - "Esc dismisses with denied + dismissed reason (fail-closed)"

## Why bridge injection (not real LSP)

The full LSP-fires-request → modal → user-clicks → response-flows-back path is exercised in [lex-fmt/vscode#68](https://github.com/lex-fmt/vscode/pull/68) against a real \`lexd-lsp\` v0.11.0 binary. lexed's e2e covers the React/Electron-specific UI layer, the coordinator's Promise plumbing, and the click-handler routing — without the cost of standing up a workspace fixture and waiting on a subprocess spawn attempt inside Electron.

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npx vitest run\` — 146/146 pass.
- [x] Playwright e2e: 4/4 trust-prompt tests pass against a built bundle (5.5s total). Pre-commit's \`test:e2e:built\` runs them as part of the full suite.

## Sequencing

After this merges, cut the lexed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)