### PR TITLE
feat: extract-to-include command + lexd-lsp v0.12.0 (#498)

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.11.0",
+      "version": "v0.12.0",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PaneWorkspace } from './components/PaneWorkspace'
 import { usePersistedPaneLayout } from '@/panes/usePersistedPaneLayout'
 import { usePaneManager } from '@/panes/usePaneManager'
 import {
+  extractToInclude,
   insertAsset,
   insertVerbatim,
   resolveAnnotation,
@@ -34,6 +35,7 @@ import { getVisualPaneOrder, getVisualTabOrder } from '@/panes/order'
 import { CommandPalette } from '@/components/CommandPalette'
 import { ShortcutsModal } from '@/components/ShortcutsModal'
 import { LspErrorModal } from '@/components/LspErrorModal'
+import { ExtractToIncludeModal } from '@/components/ExtractToIncludeModal'
 import log from 'electron-log/renderer'
 
 interface LspErrorInfo {
@@ -81,6 +83,7 @@ function AppContent() {
   const [isShortcutsOpen, setShortcutsOpen] = useState(false)
   const [lspError, setLspError] = useState<LspErrorInfo | null>(null)
   const [isLspModalOpen, setLspModalOpen] = useState(false)
+  const [isExtractModalOpen, setExtractModalOpen] = useState(false)
   const handleShortcutsClose = useCallback(() => {
     if (isShortcutsOpen) {
       log.info('[Keybindings] Close shortcuts modal')
@@ -573,6 +576,32 @@ function AppContent() {
     await toggleAnnotations(activeEditor)
   }, [activeEditor, ensureLspAvailable])
 
+  const handleExtractToInclude = useCallback(() => {
+    if (!ensureLspAvailable()) return
+    if (!activeEditor) return
+    const selection = activeEditor.getSelection()
+    if (!selection || selection.isEmpty()) {
+      toast.info('Select some text first to extract into a new include file')
+      return
+    }
+    setExtractModalOpen(true)
+  }, [activeEditor, ensureLspAvailable])
+
+  const handleExtractSubmit = useCallback(
+    async (src: string) => {
+      setExtractModalOpen(false)
+      if (!activeEditor) return
+      try {
+        await extractToInclude(activeEditor, src)
+        toast.success(`Extracted selection to ${src}`)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        toast.error(`Extract to include failed: ${message}`)
+      }
+    },
+    [activeEditor]
+  )
+
   const handleToggleHiddenFiles = useCallback(async () => {
     const current = settings.fileTree.showHiddenFiles
     await updateFileTreeSettings({ showHiddenFiles: !current })
@@ -737,6 +766,10 @@ function AppContent() {
         }
         return false
       }
+      if (actionId === 'editor.extractToInclude') {
+        handleExtractToInclude()
+        return true
+      }
       return false
     },
     [
@@ -744,6 +777,7 @@ function AppContent() {
       focusPaneByIndex,
       handleCopyPath,
       handleCopyRelativePath,
+      handleExtractToInclude,
       handleReplace,
       handleSplitHorizontal,
       handleSplitVertical,
@@ -1013,6 +1047,11 @@ function AppContent() {
           autoDismissMs={15000}
         />
       )}
+      <ExtractToIncludeModal
+        isOpen={isExtractModalOpen}
+        onSubmit={handleExtractSubmit}
+        onCancel={() => setExtractModalOpen(false)}
+      />
     </>
   )
 }

--- a/src/components/ExtractToIncludeModal.tsx
+++ b/src/components/ExtractToIncludeModal.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface ExtractToIncludeModalProps {
+  isOpen: boolean
+  onSubmit: (src: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Modal prompting the user for the include path that `lex.extractToInclude`
+ * will write the current selection to. The submitted value is passed to the
+ * LSP command unchanged — server-side validation
+ * (`lex_lsp::features::extract::validate_include_path`) handles path-shape
+ * errors and surfaces them through the standard error toast.
+ *
+ * Mirrors `LspErrorModal.tsx` and `TrustPromptModal.tsx` for visual
+ * consistency.
+ */
+export function ExtractToIncludeModal({ isOpen, onSubmit, onCancel }: ExtractToIncludeModalProps) {
+  const [src, setSrc] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Reset and focus on open. The trust-prompt modal does the same;
+  // keeps the input box from carrying stale values between invocations.
+  useEffect(() => {
+    if (!isOpen) return
+    setSrc('')
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [isOpen])
+
+  // Esc cancels, matching the trust-prompt + LSP-error modals.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  const submit = () => {
+    const trimmed = src.trim()
+    if (!trimmed) return
+    onSubmit(trimmed)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center py-24"
+      style={{ backgroundColor: 'var(--locked-content-overlay)' }}
+      onClick={onCancel}
+    >
+      <div
+        className="w-[500px] rounded-lg border border-border bg-panel shadow-xl text-foreground"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="border-b border-border px-4 py-3 text-sm font-semibold">
+          Extract selection to include
+        </div>
+        <div className="space-y-4 px-4 py-4 text-sm">
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Path for the new include file, relative to the includes root.
+          </p>
+          <input
+            ref={inputRef}
+            value={src}
+            onChange={(e) => setSrc(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                submit()
+              }
+            }}
+            placeholder="e.g. chapters/intro.lex"
+            className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm outline-none focus:border-accent"
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              className="px-3 py-1.5 rounded border border-border bg-panel-hover text-sm"
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
+            <button
+              className="px-3 py-1.5 rounded border border-border bg-panel-hover text-sm disabled:opacity-50"
+              onClick={submit}
+              disabled={!src.trim()}
+            >
+              Extract
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/editing.ts
+++ b/src/features/editing.ts
@@ -104,3 +104,143 @@ export async function resolveAnnotation(editor: monaco.editor.IStandaloneCodeEdi
 export async function toggleAnnotations(editor: monaco.editor.IStandaloneCodeEditor) {
   await invokeInsertCommand(editor, 'lex.toggle_annotations', [])
 }
+
+// ============================================================================
+// Extract-to-include (lex#497)
+// ============================================================================
+
+interface LspPosition {
+  line: number
+  character: number
+}
+interface LspRange {
+  start: LspPosition
+  end: LspPosition
+}
+interface LspTextEdit {
+  range: LspRange
+  newText: string
+}
+type LspDocumentChange =
+  | { kind: 'create'; uri: string; options?: { overwrite?: boolean; ignoreIfExists?: boolean } }
+  | { textDocument: { uri: string; version: number | null }; edits: LspTextEdit[] }
+
+interface LspWorkspaceEdit {
+  documentChanges?: LspDocumentChange[]
+}
+
+function fsPathFromUri(uri: string): string {
+  // file:///abs/path -> /abs/path. Stay defensive for non-file URIs.
+  const url = new URL(uri)
+  if (url.protocol !== 'file:') {
+    throw new Error(`Cannot apply edit to non-file URI: ${uri}`)
+  }
+  return decodeURIComponent(url.pathname)
+}
+
+/**
+ * Apply a WorkspaceEdit returned by `lex.extractToInclude`. The server
+ * produces a three-op sequence:
+ *   1. `CreateFile` for the new include target.
+ *   2. `TextDocumentEdit` writing the indent-shifted selection into it.
+ *   3. `TextDocumentEdit` replacing the host selection with the include
+ *      annotation.
+ *
+ * Op 3 lands as a Monaco edit on the active editor (its URI matches the
+ * model). Ops 1+2 land as a single `file-save` IPC — fewer round-trips
+ * than separate "create then write" calls, and matches what the server
+ * expects (the CreateFile op is a marker; the content always arrives via
+ * the paired TextDocumentEdit at position (0,0)).
+ */
+async function applyExtractWorkspaceEdit(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  edit: LspWorkspaceEdit
+): Promise<void> {
+  const model = editor.getModel()
+  if (!model) {
+    throw new Error('No active editor model')
+  }
+  const ops = edit.documentChanges ?? []
+  if (ops.length === 0) {
+    throw new Error('Workspace edit had no operations')
+  }
+
+  const hostUri = model.uri.toString()
+  // Collect file-creation targets so we can pair them with their content edits.
+  const createTargets = new Set<string>()
+  for (const op of ops) {
+    if ('kind' in op && op.kind === 'create') {
+      createTargets.add(op.uri)
+    }
+  }
+
+  for (const op of ops) {
+    if ('kind' in op && op.kind === 'create') {
+      // Defer the on-disk write until we see the paired TextDocumentEdit
+      // that carries the content. The server always emits both in order.
+      continue
+    }
+    if (!('textDocument' in op)) continue
+    const { uri } = op.textDocument
+    const newText = op.edits.map((e) => e.newText).join('')
+
+    if (uri === hostUri) {
+      // Replace the selection in the active editor.
+      const monacoEdits = op.edits.map((e) => ({
+        range: new monaco.Range(
+          e.range.start.line + 1,
+          e.range.start.character + 1,
+          e.range.end.line + 1,
+          e.range.end.character + 1
+        ),
+        text: e.newText,
+        forceMoveMarkers: true,
+      }))
+      editor.executeEdits('lex-extract-to-include', monacoEdits)
+      continue
+    }
+    // Target file: write content via IPC. The matching CreateFile op is
+    // implicit — `fileSave` creates parents-must-exist semantics, which
+    // is fine because the server's validator already enforced parent-dir
+    // existence (ExtractError::ParentDirMissing).
+    if (!createTargets.has(uri)) {
+      throw new Error(`Refusing to write a non-host URI without a CreateFile op: ${uri}`)
+    }
+    await window.ipcRenderer.invoke('file-save', fsPathFromUri(uri), newText)
+  }
+}
+
+export async function extractToInclude(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  src: string
+): Promise<void> {
+  const model = editor.getModel()
+  if (!model) throw new Error('No active editor model')
+
+  const selection = editor.getSelection()
+  if (!selection || selection.isEmpty()) {
+    throw new Error('Select some text before running extract-to-include')
+  }
+
+  // Convert Monaco's 1-indexed range to LSP's 0-indexed range.
+  const range: LspRange = {
+    start: {
+      line: selection.startLineNumber - 1,
+      character: selection.startColumn - 1,
+    },
+    end: {
+      line: selection.endLineNumber - 1,
+      character: selection.endColumn - 1,
+    },
+  }
+
+  const response = await lspClient.sendRequest<LspWorkspaceEdit | null>(
+    'workspace/executeCommand',
+    {
+      command: 'lex.extractToInclude',
+      arguments: [model.uri.toString(), range, src],
+    }
+  )
+  if (!response) throw new Error('Extract returned an empty response')
+  await applyExtractWorkspaceEdit(editor, response)
+}

--- a/src/features/editing.ts
+++ b/src/features/editing.ts
@@ -130,12 +130,25 @@ interface LspWorkspaceEdit {
 }
 
 function fsPathFromUri(uri: string): string {
-  // file:///abs/path -> /abs/path. Stay defensive for non-file URIs.
+  // Convert `file://` URIs to platform-native paths. On Windows, a URI like
+  // `file:///C:/Users/foo` has `pathname == "/C:/Users/foo"` — passing that
+  // verbatim to `fs.writeFile` fails because of the leading slash before
+  // the drive letter. Strip it on win32.
   const url = new URL(uri)
   if (url.protocol !== 'file:') {
     throw new Error(`Cannot apply edit to non-file URI: ${uri}`)
   }
-  return decodeURIComponent(url.pathname)
+  let path = decodeURIComponent(url.pathname)
+  if (
+    typeof window !== 'undefined' &&
+    window.navigator &&
+    window.navigator.platform &&
+    window.navigator.platform.startsWith('Win') &&
+    /^\/[A-Za-z]:/.test(path)
+  ) {
+    path = path.slice(1)
+  }
+  return path
 }
 
 /**
@@ -182,7 +195,6 @@ async function applyExtractWorkspaceEdit(
     }
     if (!('textDocument' in op)) continue
     const { uri } = op.textDocument
-    const newText = op.edits.map((e) => e.newText).join('')
 
     if (uri === hostUri) {
       // Replace the selection in the active editor.
@@ -206,7 +218,28 @@ async function applyExtractWorkspaceEdit(
     if (!createTargets.has(uri)) {
       throw new Error(`Refusing to write a non-host URI without a CreateFile op: ${uri}`)
     }
-    await window.ipcRenderer.invoke('file-save', fsPathFromUri(uri), newText)
+    // The server contract for a newly-created file is exactly one edit
+    // inserting the full content at (0,0). Collapsing `op.edits` via
+    // `map(...).join('')` would lose ordering if that ever changed, so
+    // assert the shape up front rather than silently producing wrong
+    // content. If we need to support multi-edit creates later, this
+    // throw forces a deliberate update of the apply path (LSP TextEdit[]
+    // base semantics, base-then-apply ordering).
+    if (op.edits.length !== 1) {
+      throw new Error(`Expected a single content edit for new file ${uri}, got ${op.edits.length}`)
+    }
+    const contentEdit = op.edits[0]
+    if (
+      contentEdit.range.start.line !== 0 ||
+      contentEdit.range.start.character !== 0 ||
+      contentEdit.range.end.line !== 0 ||
+      contentEdit.range.end.character !== 0
+    ) {
+      throw new Error(
+        `Expected new-file edit range to be (0,0)-(0,0), got ${JSON.stringify(contentEdit.range)}`
+      )
+    }
+    await window.ipcRenderer.invoke('file-save', fsPathFromUri(uri), contentEdit.newText)
   }
 }
 

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -86,4 +86,13 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     contexts: ['editor'],
     shortcut: 'cmd+shift+p',
   },
+  {
+    id: 'editor.extractToInclude',
+    title: 'Extract Selection to Include File',
+    description:
+      'Split the current selection into a new include file referenced via :: lex.include ::',
+    category: 'Editor',
+    contexts: ['editor'],
+    shortcut: 'cmd+shift+e',
+  },
 ]


### PR DESCRIPTION
## Summary
- Per [lex#498](https://github.com/lex-fmt/lex/issues/498). Hooks lexed into the `lex.extractToInclude` LSP workspace command shipped in [lexd-lsp v0.12.0](https://github.com/lex-fmt/lex/releases/tag/v0.12.0) ([lex#497](https://github.com/lex-fmt/lex/issues/497)).
- Bumps `shared/lex-deps.json` pin v0.11.0 → v0.12.0 (nested `.deps.lexd-lsp.version` schema).
- Adds an `extractToInclude` feature function, a modal prompt component, a keybinding (`cmd+shift+e`), and `handleKeybindingAction` wiring.

## What lands
- **`src/features/editing.ts`**: new `extractToInclude(editor, src)`. Sends `workspace/executeCommand` and walks the returned LSP WorkspaceEdit's `documentChanges` — applies the host-replace `TextDocumentEdit` via `editor.executeEdits`, writes the new-file content via the existing `file-save` IPC. The `CreateFile` op is implicit (file-save's writeFile creates).
- **`src/components/ExtractToIncludeModal.tsx`**: new modal with a controlled input, Enter-submits, Esc-cancels, click-outside cancels — matches `LspErrorModal` / `TrustPromptModal` visuals.
- **`src/App.tsx`**: `handleExtractToInclude` opens the modal after confirming an active editor with a non-empty selection. `handleExtractSubmit` calls the feature and surfaces errors via the existing `toast` notification surface.
- **`src/keybindings/definitions.ts`**: new `editor.extractToInclude` action bound to `cmd+shift+e` in the editor context.

## Selection / coordinate semantics
Monaco uses 1-indexed line+column with end-exclusive ranges; LSP uses 0-indexed end-exclusive. The feature does the standard `-1` conversion on the way out (Monaco → LSP) and `+1` on the way back (LSP edit range → Monaco).

## Test plan
- [x] Type-check (`npx tsc --noEmit`) clean.
- [x] Pre-commit (eslint + unit + 46 e2e tests including packaged build) clean.
- [ ] Manual smoke in dev build: select text in a `.lex` buffer, hit `cmd+shift+e`, enter a target path, verify the new file appears on disk with the indent-shifted content and the host buffer gets `:: lex.include ... ::` at the original indent.
- [ ] Manual error path: invalid path (`/abs/outside-root.lex` or already-existing target) → error message from server renders in the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)