### PR TITLE
chore: bump lexd-lsp pin v0.12.0 → v0.13.0

### DIFF
--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -1,7 +1,7 @@
 {
   "deps": {
     "lexd-lsp": {
-      "version": "v0.12.0",
+      "version": "v0.13.0",
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -31,9 +31,9 @@ test.describe('LexEd Features', () => {
       win.webContents.send('menu-insert-asset')
     })
 
-    await waitForEditorContent(page, 'doc.image')
+    await waitForEditorContent(page, ':: image src=')
 
-    await expectEditorValue(page, 'doc.image')
+    await expectEditorValue(page, ':: image src=')
     await expectEditorValue(page, 'test-asset.png')
   })
 


### PR DESCRIPTION
## Summary

- Bumps `lexd-lsp` pin v0.12.0 → v0.13.0 ([lex v0.13.0 release](https://github.com/lex-fmt/lex/releases/tag/v0.13.0)). Pulls in the bare-as-blessed label namespace model ([lex#584](https://github.com/lex-fmt/lex/issues/584)) and wire-v2 reverse-hook surface ([lex#583](https://github.com/lex-fmt/lex/issues/583)).
- Bumps `comms` submodule to `2238b40` to match lex's pin.

CHANGELOG entry deferred to the release-tag commit (per the lexed convention — no `UNRELEASED.md` in this repo).

## What users see

All four behaviours flow through standard LSP — no electron-side wiring needed:

- **Label-policy diagnostics** on `:: doc.foo ::` (reserved-forbidden) and `:: lex.unknown ::` (unregistered canonical), with codes `forbidden-label-prefix` / `unknown-lex-canonical`.
- **Quickfix code action** "Rewrite \`doc.table\` to \`table\`" (+ analogous for the four curated mappings, + generic "strip \`doc.\` prefix" fallback).
- **Hover form-classification** — "Shortcut for \`lex.metadata.author\`" / "Prefix-stripped form of …" / "Community label".
- **Permissive parse for diagnostics** — `:: doc.foo ::` no longer blanks out the rest of the LSP surface.

## Test plan

- [x] Local smoke test: downloaded `lexd-lsp-aarch64-apple-darwin.tar.gz` from the v0.13.0 release, binary launches (signed + notarized).
- [x] Local pre-commit (typecheck + build + unit tests + e2e) passed.
- [ ] CI green
- [ ] Manual: open a `.lex` file with `:: doc.foo ::`, verify diagnostic + quickfix