### PR TITLE
test(e2e): cover label-policy diagnostics, quickfix, hover, completion

### DIFF
--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -216,6 +216,109 @@ export function useLexTestBridge({
           context: { includeDeclaration: true },
         })
       },
+      requestHover: async (line: number, column: number) => {
+        const editorInstance = getActiveEditorInstance()
+        const model = editorInstance?.getModel?.()
+        if (!model) return null
+        return lspClient.sendRequest('textDocument/hover', {
+          textDocument: { uri: model.uri.toString() },
+          position: { line: line - 1, character: column - 1 },
+        })
+      },
+      requestCodeActions: async (
+        line: number,
+        column: number,
+        diagnostic?: {
+          range: {
+            start: { line: number; character: number }
+            end: { line: number; character: number }
+          }
+          severity?: number
+          code?: string | number
+          source?: string
+          message?: string
+        }
+      ) => {
+        const editorInstance = getActiveEditorInstance()
+        const model = editorInstance?.getModel?.()
+        if (!model) return null
+        const range = diagnostic?.range ?? {
+          start: { line: line - 1, character: column - 1 },
+          end: { line: line - 1, character: column - 1 },
+        }
+        return lspClient.sendRequest('textDocument/codeAction', {
+          textDocument: { uri: model.uri.toString() },
+          range,
+          context: {
+            diagnostics: diagnostic ? [diagnostic] : [],
+            only: ['quickfix'],
+          },
+        })
+      },
+      // Append text to the active model via `executeEdits`, mirroring
+      // what user typing does (LSP picks up the didChange via its
+      // normal listener). Returns the 1-based line number of the
+      // first inserted line, so tests can position the cursor there.
+      appendToEditor: (text: string): number | null => {
+        const editorInstance = getActiveEditorInstance()
+        const model = editorInstance?.getModel?.()
+        if (!editorInstance || !model) return null
+        const lastLine = model.getLineCount()
+        const lastColumn = model.getLineLength(lastLine) + 1
+        const insertedFirstLine = lastLine
+        editorInstance.executeEdits('lex-test-append', [
+          {
+            range: new monaco.Range(lastLine, lastColumn, lastLine, lastColumn),
+            text,
+            forceMoveMarkers: true,
+          },
+        ])
+        return insertedFirstLine
+      },
+      applyWorkspaceEdit: (edit: {
+        changes?: Record<
+          string,
+          Array<{
+            range: {
+              start: { line: number; character: number }
+              end: { line: number; character: number }
+            }
+            newText: string
+          }>
+        >
+      }) => {
+        // Minimal applier for the LSP WorkspaceEdit `changes` form
+        // (which is what lex-lsp emits for label-policy quickfixes).
+        // LSP ranges are 0-indexed line/char; Monaco wants 1-indexed
+        // line/column — converting both ends. Edits are applied in
+        // descending order so an earlier edit doesn't shift later
+        // ranges.
+        if (!edit.changes) return false
+        for (const [uri, edits] of Object.entries(edit.changes)) {
+          const model = monaco.editor.getModel(monaco.Uri.parse(uri))
+          if (!model) continue
+          const sorted = [...edits].sort((a, b) => {
+            if (a.range.start.line !== b.range.start.line) {
+              return b.range.start.line - a.range.start.line
+            }
+            return b.range.start.character - a.range.start.character
+          })
+          for (const e of sorted) {
+            model.applyEdits([
+              {
+                range: new monaco.Range(
+                  e.range.start.line + 1,
+                  e.range.start.character + 1,
+                  e.range.end.line + 1,
+                  e.range.end.character + 1
+                ),
+                text: e.newText,
+              },
+            ])
+          }
+        }
+        return true
+      },
       triggerFormatTable: async () => {
         const editorInstance = getActiveEditorInstance()
         if (!editorInstance) return false

--- a/tests/e2e/label-policy.spec.ts
+++ b/tests/e2e/label-policy.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect, expectMarkers, waitForLsp } from './lib'
+import { openFixture } from './helpers'
+
+// The fixture mirrors vscode/test/fixtures/sample-workspace/documents/label-policy.lex
+// and nvim/test/test_lsp_label_policy.lua's inline fixture line-for-line, so
+// the three editor suites assert against the same source structure.
+//
+// 1-indexed lines (Monaco's convention):
+//   4: `:: doc.table ::`              — forbidden, curated quickfix
+//   9: `:: doc.unknownthing ::`        — forbidden, generic strip-fallback
+//   12: `:: lex.notarealsemantic ::`   — unknown-lex-canonical
+//   15: `:: title :: Example Doc`      — Shortcut form
+//   17: `:: metadata.author :: Alice`  — Stripped form
+//   19: `:: acme.task :: ...`          — Community form
+const DOC_TABLE_LINE = 4
+const DOC_UNKNOWNTHING_LINE = 9
+const LEX_NOTREAL_LINE = 12
+
+interface LspDiagnostic {
+  range: {
+    start: { line: number; character: number }
+    end: { line: number; character: number }
+  }
+  severity?: number
+  code?: string | number
+  source?: string
+  message?: string
+}
+
+interface LspMarkupContent {
+  kind?: string
+  value: string
+}
+
+interface LspHover {
+  contents?: string | LspMarkupContent | Array<string | LspMarkupContent>
+}
+
+interface LspCodeAction {
+  title: string
+  kind?: string
+  edit?: {
+    changes?: Record<string, Array<{ range: unknown; newText: string }>>
+  }
+  command?: { command: string; arguments?: unknown[] }
+}
+
+function unwrapHoverText(hover: LspHover | null | undefined): string {
+  if (!hover?.contents) return ''
+  const contents = hover.contents
+  if (typeof contents === 'string') return contents
+  if (Array.isArray(contents)) {
+    return contents.map((c) => (typeof c === 'string' ? c : c.value)).join('\n')
+  }
+  return contents.value ?? ''
+}
+
+test.describe('Label policy', () => {
+  test('diagnostics surface for doc.* and unknown lex.* labels', async ({ page }) => {
+    await openFixture(page, 'label-policy.lex')
+    await waitForLsp(page)
+
+    await expectMarkers(page, [
+      {
+        message: 'doc.table',
+        severity: 'error',
+        startLineNumber: DOC_TABLE_LINE,
+        source: 'lex',
+      },
+      {
+        message: 'doc.unknownthing',
+        severity: 'error',
+        startLineNumber: DOC_UNKNOWNTHING_LINE,
+        source: 'lex',
+      },
+      {
+        message: 'lex.notarealsemantic',
+        severity: 'error',
+        startLineNumber: LEX_NOTREAL_LINE,
+        source: 'lex',
+      },
+    ])
+  })
+
+  test('quickfix rewrites :: doc.table :: to :: table ::', async ({ page }) => {
+    await openFixture(page, 'label-policy.lex')
+    await waitForLsp(page)
+
+    // Pick the forbidden-label-prefix marker on the doc.table line so the
+    // code-action request carries the same diagnostic the LSP attached to.
+    const diagnostic = await page.evaluate((line) => {
+      const markers = window.__e2e.bridge?.getMarkers?.() ?? []
+      // Monaco markers are 1-indexed; LSP positions are 0-indexed. We send
+      // the marker back as an LSP-shaped diagnostic for the code-action
+      // context, so the request looks indistinguishable from the one the
+      // editor would send when the user opens the lightbulb menu.
+      const marker = markers.find(
+        (m: { startLineNumber: number; message: string; source: string }) =>
+          m.startLineNumber === line && m.message.includes('doc.table') && m.source === 'lex'
+      ) as
+        | {
+            startLineNumber: number
+            startColumn: number
+            endLineNumber: number
+            endColumn: number
+            severity: number
+            code?: string | number
+            source: string
+            message: string
+          }
+        | undefined
+      if (!marker) return null
+      return {
+        range: {
+          start: { line: marker.startLineNumber - 1, character: marker.startColumn - 1 },
+          end: { line: marker.endLineNumber - 1, character: marker.endColumn - 1 },
+        },
+        severity: marker.severity,
+        code: marker.code,
+        source: marker.source,
+        message: marker.message,
+      }
+    }, DOC_TABLE_LINE)
+
+    expect(diagnostic, 'doc.table forbidden-label-prefix marker should be present').not.toBeNull()
+
+    const actions = await page.evaluate(
+      async ({ line, diag }) => {
+        return (await window.__e2e.bridge.requestCodeActions?.(line, 1, diag as LspDiagnostic)) as
+          | LspCodeAction[]
+          | null
+      },
+      { line: DOC_TABLE_LINE, diag: diagnostic as LspDiagnostic }
+    )
+
+    expect(actions, 'code-action request should return a result').not.toBeNull()
+    const rewrite = (actions ?? []).find(
+      (a) => a.title.toLowerCase().includes('rewrite') && a.title.includes('table')
+    )
+    expect(
+      rewrite,
+      `expected "Rewrite doc.table to table" action; got: ${(actions ?? []).map((a) => a.title).join(', ')}`
+    ).toBeTruthy()
+
+    // Apply the workspace edit and confirm the line flipped.
+    if (rewrite?.edit) {
+      const applied = await page.evaluate(
+        (edit) => window.__e2e.bridge.applyWorkspaceEdit?.(edit) ?? false,
+        rewrite.edit
+      )
+      expect(applied, 'applyWorkspaceEdit should succeed').toBe(true)
+    } else {
+      throw new Error('label-policy quickfix had no inline edit')
+    }
+
+    const newLine = await page.evaluate(
+      (line) => window.__e2e.bridge.getLineContent?.(line),
+      DOC_TABLE_LINE
+    )
+    expect(newLine, `line should flip to ":: table ::"; got ${newLine}`).toMatch(/:: table ::/)
+    expect(newLine, 'line should no longer carry doc.table').not.toMatch(/doc\.table/)
+  })
+
+  test('hover annotates shortcut / stripped / community label forms', async ({ page }) => {
+    await openFixture(page, 'label-policy.lex')
+    await waitForLsp(page)
+
+    const cases: Array<{ line: number; column: number; expect: string }> = [
+      // Position just inside the label token (after `:: `, which is 3 chars).
+      { line: 15, column: 4, expect: 'Shortcut for' }, // :: title ::
+      { line: 17, column: 4, expect: 'Prefix-stripped form' }, // :: metadata.author ::
+      { line: 19, column: 4, expect: 'Community label' }, // :: acme.task ::
+    ]
+
+    for (const c of cases) {
+      const hover = await page.evaluate(
+        async ({ line, column }) => {
+          return (await window.__e2e.bridge.requestHover?.(line, column)) as LspHover | null
+        },
+        { line: c.line, column: c.column }
+      )
+      const text = unwrapHoverText(hover)
+      expect(text, `hover on line ${c.line} should include "${c.expect}"; got: ${text}`).toContain(
+        c.expect
+      )
+    }
+  })
+
+  test('completion offers blessed shortcuts after "::"', async ({ page }) => {
+    await openFixture(page, 'label-policy.lex')
+    await waitForLsp(page)
+
+    // Append a fresh `:: ` line via Monaco's `executeEdits`. This goes
+    // through the normal change pipeline (LSP picks up `didChange` via
+    // its existing listener), unlike `setValue` which replaces the
+    // whole buffer in a single delta and races against the LSP's view.
+    // Keyboard typing was also tried but races against Monaco's
+    // auto-suggest on the `:` trigger character.
+    const triggerLine = (await page.evaluate(() => {
+      return window.__e2e.bridge.appendToEditor?.('\n\n:: ') as number | null
+    })) as number | null
+    expect(triggerLine, 'appendToEditor should return the trigger line').not.toBeNull()
+
+    await page.evaluate(
+      ({ line }) => {
+        // Cursor at column 4 = just past the trailing space after `:: `.
+        window.__e2e.bridge.setCursor?.(line + 2, 4)
+        window.__e2e.bridge.focusEditor?.()
+      },
+      { line: triggerLine as number }
+    )
+
+    // Let the LSP ingest the didChange before requesting completion.
+    await page.waitForTimeout(500)
+    await page.evaluate(() => window.__e2e.bridge.triggerSuggest?.())
+
+    // Poll the completion sample (populated by the buffer's completion
+    // provider; see packages/lex-buffer/src/lsp/providers/completion.ts).
+    await expect
+      .poll(
+        async () => {
+          const sample = await page.evaluate(() => {
+            const win = window as unknown as { __lexCompletionSample?: Array<{ label?: string }> }
+            return win.__lexCompletionSample ?? []
+          })
+          return sample.map((s) => s.label ?? '')
+        },
+        { timeout: 10000, message: 'waiting for completion sample with blessed shortcuts' }
+      )
+      .toContain('table')
+
+    const items = await page.evaluate(() => {
+      const win = window as unknown as { __lexCompletionSample?: Array<{ label?: string }> }
+      return (win.__lexCompletionSample ?? []).map((s) => s.label ?? '')
+    })
+
+    for (const expected of ['table', 'image', 'video', 'audio']) {
+      expect(items, `expected blessed shortcut "${expected}" in completions`).toContain(expected)
+    }
+    for (const item of items) {
+      expect(item, `reserved doc.* label should not be offered (got "${item}")`).not.toMatch(
+        /^doc\./
+      )
+    }
+  })
+})

--- a/tests/fixtures/label-policy.lex
+++ b/tests/fixtures/label-policy.lex
@@ -1,0 +1,21 @@
+Label Policy Smoke
+==================
+
+:: doc.table ::
+    | h1 | h2 |
+    |----|----|
+    | a  | b  |
+
+:: doc.unknownthing ::
+    not a curated mapping; expect generic strip-fallback quickfix
+
+:: lex.notarealsemantic ::
+    not a registered canonical; expect unknown-lex-canonical diagnostic
+
+:: title :: Example Doc
+
+:: metadata.author :: Alice
+
+:: acme.task :: community shape
+
+A trailing paragraph so the parser sees a complete document.


### PR DESCRIPTION
## Summary

Mirror of [vscode#72](https://github.com/lex-fmt/vscode/pull/72) and [nvim#46](https://github.com/lex-fmt/nvim/pull/46) for the bare-as-blessed label policy that landed in lex v0.13.0 ([lex#584](https://github.com/lex-fmt/lex/issues/584)). Four sub-tests in `tests/e2e/label-policy.spec.ts`:

- **Diagnostics** — `:: doc.table ::`, `:: doc.unknownthing ::`, and `:: lex.notarealsemantic ::` surface as Monaco markers (source `lex`, severity error) via the existing `getMarkers` bridge.
- **Quickfix** — `textDocument/codeAction` on the `doc.table` marker returns "Rewrite `doc.table` to `table`"; the test applies the inline `WorkspaceEdit` and verifies the buffer line flips to `:: table ::`.
- **Hover** — `:: title ::` / `:: metadata.author ::` / `:: acme.task ::` each surface their form-classification line through `textDocument/hover` (Shortcut / Prefix-stripped / Community).
- **Completion** — appending `:: ` via Monaco's `executeEdits` (the in-flight `didChange` route, vs. `setValue`'s whole-buffer replace which races against the LSP) and calling `triggerSuggest()` yields `__lexCompletionSample` containing blessed shortcuts (`table`, `image`, `video`, `audio`); reserved `doc.*` is never offered.

Fixture mirrors vscode#72 line-for-line (`tests/fixtures/label-policy.lex`).

## New `__e2e.bridge` methods

The first three additions follow the existing `requestReferences` / `requestDocumentLinks` pattern. They go straight through `lspClient.sendRequest` rather than through Monaco's provider registries so the tests verify the LSP integration end-to-end without depending on whether Monaco has registered each provider.

- `requestHover(line, column)` — `textDocument/hover`
- `requestCodeActions(line, column, diagnostic?)` — `textDocument/codeAction`, scoped to `quickfix`, with an optional LSP-shaped `Diagnostic` the test passes back to the server so the request looks identical to one the user would trigger from the lightbulb menu
- `appendToEditor(text)` — Monaco `executeEdits` append, returning the pre-insertion last-line number
- `applyWorkspaceEdit(edit)` — minimal applier for the `changes` form lex-lsp's label-policy quickfix emits; converts LSP 0-indexed ranges to Monaco's 1-indexed coordinates and applies edits in descending order so earlier edits don't shift later ranges

## Why not keyboard typing for the completion trigger

Two ways were tried and rejected before settling on `executeEdits`:

1. `page.keyboard.type('\n\n:: ')` races against Monaco's auto-suggest on `:` (a registered trigger character) and fires its own completion request before our `triggerSuggest()` call, leaving the widget in an inconsistent state.
2. `setEditorValue` (whole-buffer replace) emits a single `didChange` covering the full text replacement; the LSP-side parse can lag the test's 500ms wait on slower runners.

`executeEdits` goes through Monaco's normal change pipeline (incremental `didChange`) and gives the LSP a deterministic line to detect as a verbatim opener (`current_line.trim() == "::"`).

## Test plan

- [x] All four sub-tests pass locally against `lexd-lsp v0.13.0`.
- [x] Local pre-commit (typecheck + build + unit + e2e) passes.
- [ ] CI green