### PR TITLE
chore(cloud): import sandbox-egress CA from new standalone PEM layout

### DIFF
--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -137,6 +137,11 @@ if [ "$(uname -s)" = "Linux" ] \
    && command -v certutil >/dev/null 2>&1 \
    && command -v openssl >/dev/null 2>&1; then
   _ca_tmp="$(mktemp -d)"
+  # `set -e` means an unexpected failure in awk/cp/mkdir below would
+  # abort the script before the explicit cleanup at the end of the
+  # block, leaking a scratch dir each session. Trap EXIT (and INT/TERM
+  # so Ctrl-C during a local re-run still cleans up).
+  trap 'rm -rf "${_ca_tmp}"' EXIT INT TERM
   _found=0
 
   # Layout A: split the bundle into per-cert PEMs if it contains
@@ -182,6 +187,7 @@ if [ "$(uname -s)" = "Linux" ] \
   fi
 
   rm -rf "${_ca_tmp}"
+  trap - EXIT INT TERM
 fi
 
 # --- 3. Pre-commit hook wiring -------------------------------------------

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -114,39 +114,73 @@ fi
 # each subject; both binaries are env-level state on cloud sessions but
 # may be absent locally).
 #
-# Fast-path: grep the bundle once for the Anthropic marker before doing
-# any per-cert work. On a non-cloud Linux box the bundle has no such
-# certs and the loop is gratuitous (forks openssl ~130×); skip it
-# entirely in that case.
+# Cert layouts seen in the cloud env (probe both):
+#   (A) Historical (pre-2026-05): the sandbox-egress CA was concatenated
+#       into the system bundle /etc/ssl/certs/ca-certificates.crt.
+#   (B) Current (2026-05+): the CA ships as standalone PEMs at
+#       /etc/ssl/certs/swp-ca-{production,staging}.pem; it is NOT
+#       written into the system bundle, so the old layout-A grep gate
+#       silently misses it and the NSS DB is never populated — every
+#       HTTPS resource an Electron / Playwright test loads then fails
+#       with ERR_CERT_AUTHORITY_INVALID, even though `curl` and Node
+#       (which read the OpenSSL bundle directly, not the NSS DB)
+#       succeed. lexed's `preview.spec.ts` is the canonical surface:
+#       the LSP-generated HTML it renders pulls in a Cloudflare CDN
+#       stylesheet and a Google Fonts @import, both of which traverse
+#       the proxy.
+#
+# Strategy: collect candidate PEMs from both layouts into a scratch
+# dir, then run the existing subject-match-and-import loop over the
+# union. Fast-path: skip everything if neither layout has any
+# matching cert (non-cloud Linux box).
 if [ "$(uname -s)" = "Linux" ] \
    && command -v certutil >/dev/null 2>&1 \
-   && command -v openssl >/dev/null 2>&1 \
-   && [ -f /etc/ssl/certs/ca-certificates.crt ] \
-   && grep -q 'Anthropic' /etc/ssl/certs/ca-certificates.crt 2>/dev/null; then
-  _nssdb="${HOME}/.pki/nssdb"
-  mkdir -p "${_nssdb}"
-  if [ ! -f "${_nssdb}/cert9.db" ]; then
-    certutil -d "sql:${_nssdb}" -N --empty-password >/dev/null 2>&1 || true
-  fi
+   && command -v openssl >/dev/null 2>&1; then
   _ca_tmp="$(mktemp -d)"
-  awk '
-    /-----BEGIN CERTIFICATE-----/ { n++; fn = sandbox_dir "/cert_" n ".pem"; in_cert = 1 }
-    in_cert                       { print > fn }
-    /-----END CERTIFICATE-----/   { in_cert = 0; close(fn) }
-  ' sandbox_dir="${_ca_tmp}" /etc/ssl/certs/ca-certificates.crt
-  for _pem in "${_ca_tmp}"/cert_*.pem; do
+  _found=0
+
+  # Layout A: split the bundle into per-cert PEMs if it contains
+  # any Anthropic CA. Cheap grep gate avoids the awk fork when the
+  # bundle has no matches (the common non-cloud case).
+  if [ -f /etc/ssl/certs/ca-certificates.crt ] \
+     && grep -q 'Anthropic' /etc/ssl/certs/ca-certificates.crt 2>/dev/null; then
+    awk '
+      /-----BEGIN CERTIFICATE-----/ { n++; fn = sandbox_dir "/bundle_" n ".pem"; in_cert = 1 }
+      in_cert                       { print > fn }
+      /-----END CERTIFICATE-----/   { in_cert = 0; close(fn) }
+    ' sandbox_dir="${_ca_tmp}" /etc/ssl/certs/ca-certificates.crt
+    _found=1
+  fi
+
+  # Layout B: copy standalone swp-ca-*.pem into the scratch dir.
+  # The glob can be unexpanded if no file matches; guard with -f.
+  for _pem in /etc/ssl/certs/swp-ca-*.pem; do
     [ -f "${_pem}" ] || continue
-    _subject="$(openssl x509 -in "${_pem}" -noout -subject 2>/dev/null || true)"
-    case "${_subject}" in
-      *Anthropic*sandbox-egress*)
-        _nick="$(printf '%s' "${_subject}" | sed -nE 's/.*CN *= *([^,]+).*/\1/p')"
-        [ -n "${_nick}" ] || continue
-        if ! certutil -d "sql:${_nssdb}" -L -n "${_nick}" >/dev/null 2>&1; then
-          certutil -d "sql:${_nssdb}" -A -t "C,," -n "${_nick}" -i "${_pem}" >/dev/null 2>&1 || true
-        fi
-        ;;
-    esac
+    cp "${_pem}" "${_ca_tmp}/$(basename "${_pem}")"
+    _found=1
   done
+
+  if [ "${_found}" = "1" ]; then
+    _nssdb="${HOME}/.pki/nssdb"
+    mkdir -p "${_nssdb}"
+    if [ ! -f "${_nssdb}/cert9.db" ]; then
+      certutil -d "sql:${_nssdb}" -N --empty-password >/dev/null 2>&1 || true
+    fi
+    for _pem in "${_ca_tmp}"/*.pem; do
+      [ -f "${_pem}" ] || continue
+      _subject="$(openssl x509 -in "${_pem}" -noout -subject 2>/dev/null || true)"
+      case "${_subject}" in
+        *Anthropic*sandbox-egress*)
+          _nick="$(printf '%s' "${_subject}" | sed -nE 's/.*CN *= *([^,]+).*/\1/p')"
+          [ -n "${_nick}" ] || continue
+          if ! certutil -d "sql:${_nssdb}" -L -n "${_nick}" >/dev/null 2>&1; then
+            certutil -d "sql:${_nssdb}" -A -t "C,," -n "${_nick}" -i "${_pem}" >/dev/null 2>&1 || true
+          fi
+          ;;
+      esac
+    done
+  fi
+
   rm -rf "${_ca_tmp}"
 fi
 


### PR DESCRIPTION
## Issue

After PR #94 wired the NSS-DB cert import for Electron / Playwright, fresh cloud sessions still fail one e2e test:

```
[dev] › tests/e2e/preview.spec.ts:4:3 › Preview Feature › opens HTML preview for lex file
  Error: Runtime errors captured during test (1):
    [1] (console) Failed to load resource: net::ERR_CERT_AUTHORITY_INVALID
```

Other tests pass (typecheck, lint, build, 146 unit tests, 49/50 e2e), and `curl https://...` from a shell works fine, so the OpenSSL trust path is healthy. Chromium's NSS DB is the only thing missing the sandbox-egress CA.

## Root cause

The cloud env shifted where the sandbox-egress TLS-inspection CA lives:

- **Before (~ pre-2026-05):** concatenated into the system bundle `/etc/ssl/certs/ca-certificates.crt` alongside the public-root CAs.
- **Now:** two standalone PEMs, `/etc/ssl/certs/swp-ca-{production,staging}.pem` (with companion `.crt` symlinks via `c_rehash`), **not** in the system bundle.

The cert-import block in `setup-dev-env.sh` gates on `grep -q 'Anthropic' /etc/ssl/certs/ca-certificates.crt`. Under the new layout that grep returns 0 matches, the whole import section is skipped silently, `~/.pki/nssdb` is never created, and Chromium rejects every HTTPS resource the renderer loads.

`preview.spec.ts` is the canonical surface: the LSP-generated preview HTML for `welcome/general.lex` pulls in
- `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/.../github.min.css`
- `@import url('https://fonts.googleapis.com/css2?family=Geist...')`

— both traverse the egress proxy. The harness's `runtimeErrors` collector promotes the console error to a test failure.

(The URLs are baked into the `lexd-lsp` binary's HTML template, so rewriting the test or fixture wouldn't avoid them.)

## Fix

Probe both cert layouts in `scripts/setup-dev-env.sh`:

1. If `/etc/ssl/certs/ca-certificates.crt` contains the `Anthropic` marker, split it per-cert as before.
2. Independently, copy any `/etc/ssl/certs/swp-ca-*.pem` files into the same scratch dir (guarded with `-f` so the unexpanded glob is a no-op).
3. Run the existing subject-match (`*Anthropic*sandbox-egress*`) and `certutil -A` import loop over the union.

Idempotent — the `certutil -L -n <nick>` check before each `-A` means re-runs are no-ops once a cert is present. Skip-fast when neither layout matches (non-cloud Linux box).

## Verification

```bash
rm -rf ~/.pki/nssdb
CLAUDE_CODE_REMOTE=true bash scripts/setup-dev-env.sh
certutil -d "sql:$HOME/.pki/nssdb" -L
# → sandbox-egress-production TLS Inspection CA   C,,
# → sandbox-egress-staging    TLS Inspection CA   C,,

DISPLAY=:99 npm run test:e2e:built
# → 50 passed (3.4m)
```

Full local pre-commit hook (lint-staged + typecheck + build + unit + e2e) also green.

## Follow-up

This belongs upstream in `arthur-debert/release` `templates/setup-dev-env.sh` so every consumer repo picks it up on the next template sync — the section is above the `--- 4. Project-local extras ---` marker and is identical across stacks. Will file a `release-issue-relay` once this lands.

https://claude.ai/code/session_017WMBRKf21gLzDVAWE4bNSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017WMBRKf21gLzDVAWE4bNSQ)_