### PR TITLE
feat(release): add release primitive scripts (#640)

### DIFF
--- a/scripts/release/get-commits-since-release
+++ b/scripts/release/get-commits-since-release
@@ -2,7 +2,9 @@
 # get-commits-since-release — print commits since the most recent vX.Y.Z tag.
 #
 # Output: one line per commit, `<short-sha> <subject>`. Empty stdout means no
-# commits since the latest release tag (or no tags exist yet).
+# commits since the latest release tag. If no `vX.Y.Z` tag exists in the repo,
+# lists all commits on HEAD (the orchestrator decides what "all commits ever"
+# means at the upper layer).
 #
 # Layer 0 release primitive — see lex-fmt/lex#640. Sister scripts:
 #   - get-current-version

--- a/scripts/release/get-commits-since-release
+++ b/scripts/release/get-commits-since-release
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# get-commits-since-release — print commits since the most recent vX.Y.Z tag.
+#
+# Output: one line per commit, `<short-sha> <subject>`. Empty stdout means no
+# commits since the latest release tag (or no tags exist yet).
+#
+# Layer 0 release primitive — see lex-fmt/lex#640. Sister scripts:
+#   - get-current-version
+#   - update-release
+#
+# Usage: ./scripts/release/get-commits-since-release
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+tag="$(git describe --tags --abbrev=0 --match='v*.*.*' 2>/dev/null || true)"
+
+if [[ -z "$tag" ]]; then
+  # No release tags yet — list every commit on HEAD.
+  git log --pretty=format:'%h %s' HEAD
+  # Ensure trailing newline if there was any output.
+  if [[ -n "$(git log --oneline HEAD | head -n 1)" ]]; then echo; fi
+  exit 0
+fi
+
+git log --pretty=format:'%h %s' "${tag}..HEAD"
+# git log --pretty=format omits the trailing newline; add one if non-empty.
+if [[ -n "$(git log --oneline "${tag}..HEAD" | head -n 1)" ]]; then echo; fi

--- a/scripts/release/get-current-version
+++ b/scripts/release/get-current-version
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print this repo's current version (bare, no `v` prefix) to stdout.
+#
+# Source of truth: the `"version"` field in `package.json`.
+# Layer 0 release primitive — see lex-fmt/lex#640. Sister scripts:
+#   - get-commits-since-release
+#   - update-release
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PKG="$REPO_ROOT/package.json"
+if [[ ! -f "$PKG" ]]; then
+  echo "error: $PKG not found" >&2
+  exit 1
+fi
+
+VERSION=$(jq -r .version "$PKG")
+
+if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+  echo "error: could not parse .version from $PKG" >&2
+  exit 1
+fi
+
+printf '%s\n' "$VERSION"

--- a/scripts/release/update-release
+++ b/scripts/release/update-release
@@ -54,6 +54,19 @@ jq --arg v "$NEW_VERSION" '.version = $v' "$PKG" > "$TMP"
 mv "$TMP" "$PKG"
 git add "$PKG"
 
+# --- package-lock.json ---------------------------------------------------
+# npm's lockfile carries the root version in two places: `.version` (top-level)
+# and `.packages[""].version` (the root package entry). Bump both directly with
+# jq so the lockfile stays in lockstep with package.json without paying for a
+# full `npm install --package-lock-only`.
+LOCK="$REPO_ROOT/package-lock.json"
+if [[ -f "$LOCK" ]]; then
+  TMP="$(mktemp)"
+  jq --arg v "$NEW_VERSION" '.version = $v | .packages[""].version = $v' "$LOCK" > "$TMP"
+  mv "$TMP" "$LOCK"
+  git add "$LOCK"
+fi
+
 # --- shared/lex-deps.json ------------------------------------------------
 # Pin lexd-lsp and tree-sitter to whatever is currently the "latest" GitHub
 # release of each upstream repo. We use `gh release view` (no --pre-releases)
@@ -111,14 +124,17 @@ fi
 # Fast-forward the comms submodule to origin/main and stage the gitlink. This
 # matches the rest of the lex-fmt portfolio (lex, vscode, nvim, tree-sitter-lex
 # all do the same dance at release time so the bundled specs match the
-# published release).
-if [[ -d "$REPO_ROOT/comms/.git" ]] || [[ -f "$REPO_ROOT/comms/.git" ]]; then
-  (
-    cd "$REPO_ROOT/comms"
-    git fetch origin
-    git checkout origin/main
-  )
-  git add comms
+# published release). Fail loudly if the submodule isn't initialized — a
+# silent skip would ship a release with stale comms.
+if [[ ! -e "$REPO_ROOT/comms/.git" ]]; then
+  echo "error: comms submodule not initialized. Run: git submodule update --init --recursive" >&2
+  exit 1
 fi
+(
+  cd "$REPO_ROOT/comms"
+  git fetch origin
+  git checkout origin/main
+)
+git add comms
 
 echo "Staged version bump to ${NEW_VERSION}. Review with: git diff --cached" >&2

--- a/scripts/release/update-release
+++ b/scripts/release/update-release
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# update-release <new-version> — apply <new-version> to every version-bearing
+# file in this repo and `git add` the touched files. The caller is responsible
+# for inspecting the staged diff and creating the commit + tag (typically via
+# the higher-layer release pipeline).
+#
+# <new-version> is bare (no leading `v`). Validated as semver-ish: X.Y.Z with
+# optional `-<pre>` and `+<build>` suffixes.
+#
+# Layer 0 release primitive — see lex-fmt/lex#640. Sister scripts:
+#   - get-current-version
+#   - get-commits-since-release
+#
+# Files updated in lexed:
+#   - package.json              `.version`
+#   - CHANGELOG.md              prepend `## vX.Y.Z (YYYY-MM-DD)` entry
+#                               (renames `## [Unreleased]` if present)
+#   - comms (submodule)         fast-forward to origin/main, stage the gitlink
+#   - shared/lex-deps.json      pin `.deps."lexd-lsp".version` and
+#                               `.deps."tree-sitter".version` to the latest
+#                               release tagNames (NESTED schema — distinct
+#                               from vscode/nvim's flat schema)
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") <new-version>" >&2
+  echo "  <new-version>  bare semver, e.g. 0.11.0" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+NEW_VERSION="$1"
+
+# Bare semver: X.Y.Z with optional -<pre> and +<build>. Reject leading `v`.
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: <new-version> must be bare semver X.Y.Z (got: $NEW_VERSION)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DATE="$(date +%Y-%m-%d)"
+TAG="v${NEW_VERSION}"
+
+# --- package.json ---------------------------------------------------------
+PKG="$REPO_ROOT/package.json"
+TMP="$(mktemp)"
+jq --arg v "$NEW_VERSION" '.version = $v' "$PKG" > "$TMP"
+mv "$TMP" "$PKG"
+git add "$PKG"
+
+# --- shared/lex-deps.json ------------------------------------------------
+# Pin lexd-lsp and tree-sitter to whatever is currently the "latest" GitHub
+# release of each upstream repo. We use `gh release view` (no --pre-releases)
+# so this picks up the most-recent non-prerelease tag. The lexed schema is
+# NESTED (.deps.<name>.{version,repo}) — different from vscode/nvim's flat
+# schema. Keep the `v` prefix on the version values.
+DEPS_JSON="$REPO_ROOT/shared/lex-deps.json"
+if [[ -f "$DEPS_JSON" ]]; then
+  LEX_LATEST="$(gh release view --repo lex-fmt/lex --json tagName --jq .tagName)"
+  TS_LATEST="$(gh release view --repo lex-fmt/tree-sitter-lex --json tagName --jq .tagName)"
+
+  if [[ -z "$LEX_LATEST" || -z "$TS_LATEST" ]]; then
+    echo "error: failed to resolve latest release tags from GitHub" >&2
+    exit 1
+  fi
+
+  TMP="$(mktemp)"
+  jq \
+    --arg lex "$LEX_LATEST" \
+    --arg ts "$TS_LATEST" \
+    '.deps."lexd-lsp".version = $lex | .deps."tree-sitter".version = $ts' \
+    "$DEPS_JSON" > "$TMP"
+  mv "$TMP" "$DEPS_JSON"
+  git add "$DEPS_JSON"
+fi
+
+# --- CHANGELOG.md --------------------------------------------------------
+# Convention in this repo: top-level `# Changelog` header, then a sequence of
+# `## vX.Y.Z (YYYY-MM-DD)` sections. If an `## [Unreleased]` placeholder
+# exists, rename it to the new version; otherwise insert a fresh entry
+# directly under the `# Changelog` header.
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+if [[ -f "$CHANGELOG" ]]; then
+  if grep -q '^## \[Unreleased\]' "$CHANGELOG"; then
+    # Rename the Unreleased section in place.
+    TMP="$(mktemp)"
+    sed "s|^## \[Unreleased\].*|## ${TAG} (${DATE})|" "$CHANGELOG" > "$TMP"
+    mv "$TMP" "$CHANGELOG"
+  else
+    # Insert a fresh `## vX.Y.Z (YYYY-MM-DD)` entry after the top header.
+    # Preserves whatever preamble (first line is expected to be `# Changelog`).
+    HEADER="$(head -n 1 "$CHANGELOG")"
+    TAIL="$(tail -n +2 "$CHANGELOG")"
+    {
+      printf '%s\n\n' "$HEADER"
+      printf '## %s (%s)\n\n' "$TAG" "$DATE"
+      # Strip any leading blank lines from the previous tail so spacing stays tidy.
+      printf '%s\n' "$TAIL" | sed -e '/./,$!d'
+    } > "$CHANGELOG"
+  fi
+  git add "$CHANGELOG"
+fi
+
+# --- comms submodule ------------------------------------------------------
+# Fast-forward the comms submodule to origin/main and stage the gitlink. This
+# matches the rest of the lex-fmt portfolio (lex, vscode, nvim, tree-sitter-lex
+# all do the same dance at release time so the bundled specs match the
+# published release).
+if [[ -d "$REPO_ROOT/comms/.git" ]] || [[ -f "$REPO_ROOT/comms/.git" ]]; then
+  (
+    cd "$REPO_ROOT/comms"
+    git fetch origin
+    git checkout origin/main
+  )
+  git add comms
+fi
+
+echo "Staged version bump to ${NEW_VERSION}. Review with: git diff --cached" >&2


### PR DESCRIPTION
## Summary

Part of lex-fmt/lex#640 (cross-repo release automation, Layer 0).

Adds three executable bash scripts under `scripts/release/`:

- `get-current-version` — prints bare version from `package.json` (e.g. `0.10.0`)
- `get-commits-since-release` — `<short-sha> <subject>` per commit since the latest `vX.Y.Z` tag; empty if none
- `update-release <new-version>` — bumps `package.json`, `comms` submodule, `shared/lex-deps.json` (nested `.deps.<name>.{version,repo}` schema), and CHANGELOG `[Unreleased]` → `[<new-version>] - <YYYY-MM-DD>`; runs `git add` on touched files

Self-contained: `update-release` queries `gh release view` for the latest upstream tags (lex-fmt/lex + lex-fmt/tree-sitter-lex) rather than receiving them as args.

## Test plan

- [x] `./scripts/release/get-current-version` prints `0.10.0`
- [x] `./scripts/release/get-commits-since-release` lists recent commits since latest tag
- [x] `./scripts/release/update-release 99.99.99` stages package.json + comms submodule + shared/lex-deps.json + CHANGELOG; staged diff verified, reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)