### PR TITLE
chore(release): adopt canonical electron-app reusable workflow as thin caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,317 +1,66 @@
+# Release LexEd — thin caller into the canonical electron-app reusable
+# workflow at `arthur-debert/release/.github/workflows/electron-app.yml`.
+#
+# Trigger model: **workflow_dispatch** (matching `lex`'s pattern;
+# different from the historical tag-push that lexed used).
+# `scripts/release/trigger-release` fires this via
+# `gh workflow run release.yml -f version=<X>` — the reusable workflow's
+# prepare-release-npm action then bumps package.json, commits, tags,
+# pushes, and drives the rest (build per arch, sign via electron-
+# builder's CSC_LINK path, GH release with .dmg + .AppImage assets).
+#
+# Migration history: replaces the previous in-tree per-platform matrix
+# build (with custom smoke tests). See arthur-debert/release#65 for the
+# canonical electron-app workflow + #43 for the per-stack rollout
+# tracking issue.
+#
+# Slice-1 caveats (carried from the canonical workflow):
+# - Windows builds produce unsigned binaries (code-signing slice 3).
+# - macOS notarization is gated by `build.mac.notarize` in package.json
+#   (currently false → signing happens but notarization is skipped).
+#   Flip to `true` to enable notarization once the ASC_API_KEY_*
+#   secrets are in place.
+# - Per-platform smoke tests (linux xvfb-run launch, macOS .app spawn,
+#   etc.) ARE dropped in this slice. Slice 2 of electron-app folds an
+#   `e2e` job into the canonical workflow; until then, smoke is
+#   covered by the pre-commit / test.yml flow locally.
+
 name: Release LexEd
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
-      tag:
-        description: Release tag to build (e.g. v0.3.0)
+      version:
+        description: 'Version to release (bare semver, e.g. 0.10.2 — no leading v)'
         required: true
-      target:
-        description: Optional platform filter (linux-x64, macos-arm64, windows-x64)
-        required: false
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.vars.outputs.release_tag }}
-      manual_target: ${{ steps.vars.outputs.manual_target }}
-    steps:
-      - name: Derive release metadata
-        id: vars
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-            MANUAL_TARGET="${{ github.event.inputs.target }}"
-          else
-            TAG="${GITHUB_REF_NAME}"
-            MANUAL_TARGET=""
-          fi
+  release:
+    uses: arthur-debert/release/.github/workflows/electron-app.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      app-name: LexEd
+      bundle-id: com.lex.lexed
+      darwin-archs: arm64
+      linux-archs: x64
+      windows-archs: x64
+      submodules: true
+      changelog-path: CHANGELOG.md
+      node-version: '22'
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
 
-          if [[ -z "$TAG" ]]; then
-            echo "Release tag is required" >&2
-            exit 1
-          fi
-
-          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "manual_target=$MANUAL_TARGET" >> "$GITHUB_OUTPUT"
-
-      - name: Create or update GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_NAME: ${{ github.repository }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.vars.outputs.release_tag }}"
-          if gh release view "$TAG" --repo "$REPO_NAME" >/dev/null 2>&1; then
-            echo "Release $TAG already exists"
-          else
-            gh release create "$TAG" --repo "$REPO_NAME" --title "LexEd $TAG" --generate-notes
-          fi
-
-  build:
-    needs: prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux-x64
-            runner: ubuntu-latest
-            # `xvfb-run -a` provides a headless X11 display so the
-            # packaged Electron binary can open its window during the
-            # smoke test on a Linux runner without a real display.
-            packaged_app_path: release/linux-unpacked/lexed
-            smoke_prefix: 'xvfb-run -a'
-          - platform: macos-arm64
-            runner: macos-14
-            packaged_app_path: release/mac-arm64/LexEd.app/Contents/MacOS/LexEd
-            smoke_prefix: ''
-          - platform: windows-x64
-            runner: windows-latest
-            packaged_app_path: release\win-unpacked\LexEd.exe
-            smoke_prefix: ''
-    runs-on: ${{ matrix.runner }}
-    env:
-      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
-      # Force UTF-8 stdout/stderr in Python scripts. Default cp1252 on
-      # Windows runners can't encode characters like '✓' that some build
-      # scripts emit (e.g. gen-theme.py status output).
-      PYTHONUTF8: '1'
-    steps:
-      - name: Evaluate target filter
-        id: target-filter
-        shell: bash
-        run: |
-          set -euo pipefail
-          MANUAL_TARGET="${{ needs.prepare.outputs.manual_target }}"
-          if [[ -n "$MANUAL_TARGET" && "$MANUAL_TARGET" != "${{ matrix.platform }}" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: actions/checkout@v6
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        with:
-          submodules: true
-
-      - name: Setup Node.js
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22.18.0
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        run: npm ci
-
-      # Split the build step in two so CSC_LINK / CSC_KEY_PASSWORD are only
-      # *defined* on macOS. Setting them to "" on Windows/Linux still creates
-      # the env var and trips electron-builder's Windows signing path, which
-      # reads CSC_LINK (alias WIN_CSC_LINK), tries to resolve the empty
-      # string as a file path under the runner workspace, and fails with
-      # "Env WIN_CSC_LINK is not correct, cannot resolve: D:\a\... not a file".
-      - name: Build Electron package (macOS, signed)
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          E2E_HIDE_WINDOW: "1"
-          NODE_OPTIONS: --max-old-space-size=4096
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: npm run build
-
-      - name: Build Electron package (unsigned)
-        if: ${{ steps.target-filter.outputs.skip == 'false' && !startsWith(matrix.platform, 'macos-') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          E2E_HIDE_WINDOW: "1"
-          NODE_OPTIONS: --max-old-space-size=4096
-        run: npm run build
-
-      - name: Re-sign QuickLook plugin and re-create DMG
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        shell: bash
-        env:
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          # Import certificate into a temporary keychain
-          echo "$CSC_LINK" | base64 --decode > "$RUNNER_TEMP/cert.p12"
-          KEYCHAIN="$RUNNER_TEMP/signing.keychain"
-          security create-keychain -p "" "$KEYCHAIN"
-          security unlock-keychain -p "" "$KEYCHAIN"
-          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN"
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-          rm "$RUNNER_TEMP/cert.p12"
-
-          # Find signing identity
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | grep "Developer ID" | head -1 | awk -F'"' '{print $2}')
-          echo "Signing with: $IDENTITY"
-
-          # Find the .app
-          APP=$(ls -d release/mac-*/LexEd.app | head -1)
-          APPEX="$APP/Contents/PlugIns/LexQuickLook.appex"
-
-          if [[ -d "$APPEX" ]]; then
-            echo "Re-signing QuickLook appex..."
-            codesign --force --sign "$IDENTITY" --options runtime --timestamp \
-              --entitlements resources/entitlements.mac.plist \
-              "$APPEX"
-
-            echo "Re-signing app bundle..."
-            codesign --force --sign "$IDENTITY" --options runtime --timestamp \
-              --entitlements resources/entitlements.mac.plist \
-              "$APP"
-
-            echo "Verifying signatures..."
-            codesign --verify --deep --strict "$APP"
-
-            # Re-create DMG since the .app signature changed
-            rm -f release/*.dmg
-            APP_DIR=$(dirname "$APP")
-            ARCH=$(echo "$APP_DIR" | grep -o 'arm64\|x64')
-            VERSION=$(node -p "require('./package.json').version")
-            DMG_NAME="LexEd-${VERSION}-${ARCH}.dmg"
-            echo "Creating $DMG_NAME..."
-            hdiutil create -volname "LexEd" -srcfolder "$APP" -ov -format UDZO "release/$DMG_NAME"
-          fi
-
-      # Packaged-binary smoke test. Catches "ships but won't launch"
-      # regressions: missing bundled lexd-lsp, broken renderer mount,
-      # crash-on-startup, etc. Runs AFTER the macOS QuickLook re-sign
-      # (so the binary tested matches what ships) and BEFORE Apple
-      # notarization (so we don't pay the 30s+ notarization cost on
-      # a binary that's already known broken). On Linux, wraps the
-      # test in xvfb-run so the headless runner can open a window.
-      - name: Smoke-test the packaged binary
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        shell: bash
-        env:
-          PACKAGED_APP_PATH: ${{ matrix.packaged_app_path }}
-          PACKAGED_PLATFORM_LABEL: ${{ matrix.platform }}
-          # globalSetup would otherwise re-run `npm run build` —
-          # pointless since electron-builder just produced the package.
-          E2E_SKIP_BUILD: '1'
-        run: ${{ matrix.smoke_prefix }} npx playwright test --project=packaged
-
-      # If the smoke test fails, capture screenshots + the playwright
-      # report so the failure can be debugged from the workflow run.
-      - name: Upload smoke-test artifacts on failure
-        if: failure() && steps.target-filter.outputs.skip == 'false'
-        uses: actions/upload-artifact@v7
-        with:
-          name: packaged-smoke-${{ matrix.platform }}
-          path: |
-            tests/__screenshots__/packaged/
-            playwright-report/
-          if-no-files-found: ignore
-
-      - name: Write App Store Connect API key
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        shell: bash
-        env:
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-        run: |
-          echo "$ASC_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
-
-      - name: Submit DMG for notarization
-        id: notarize-submit
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          DMG=$(ls release/*.dmg | head -1)
-          echo "Submitting $DMG for notarization..."
-          RESULT=$(xcrun notarytool submit "$DMG" \
-            --key "$RUNNER_TEMP/AuthKey.p8" \
-            --key-id "${{ secrets.ASC_API_KEY_ID }}" \
-            --issuer "${{ secrets.ASC_API_ISSUER_ID }}" \
-            --output-format json \
-            --no-wait)
-          echo "$RESULT"
-          ID=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
-          echo "submission-id=$ID" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for notarization
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          ID="${{ steps.notarize-submit.outputs.submission-id }}"
-          for i in $(seq 1 60); do
-            RESULT=$(xcrun notarytool info "$ID" \
-              --key "$RUNNER_TEMP/AuthKey.p8" \
-              --key-id "${{ secrets.ASC_API_KEY_ID }}" \
-              --issuer "${{ secrets.ASC_API_ISSUER_ID }}" \
-              --output-format json 2>&1) || true
-            STATUS=$(echo "$RESULT" | python3 -c \
-              "import sys,json; print(json.load(sys.stdin).get('status','Unknown'))" \
-              2>/dev/null || echo "Unknown")
-            echo "  [$i/60] status=$STATUS ($(date -u +%H:%M:%S))"
-            if [ "$STATUS" = "Accepted" ]; then exit 0; fi
-            if [ "$STATUS" = "Invalid" ] || [ "$STATUS" = "Rejected" ]; then
-              xcrun notarytool log "$ID" \
-                --key "$RUNNER_TEMP/AuthKey.p8" \
-                --key-id "${{ secrets.ASC_API_KEY_ID }}" \
-                --issuer "${{ secrets.ASC_API_ISSUER_ID }}" 2>&1 || true
-              exit 1
-            fi
-            sleep 30
-          done
-          echo "::warning::Timed out after 30 min. DMG is signed but not notarized."
-
-      - name: Staple notarization ticket
-        if: ${{ steps.target-filter.outputs.skip == 'false' && startsWith(matrix.platform, 'macos-') }}
-        shell: bash
-        run: |
-          DMG=$(ls release/*.dmg | head -1)
-          xcrun stapler staple "$DMG" || echo "::warning::Staple failed — DMG is signed but not stapled"
-
-      - name: Upload release assets
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          files=(release/*)
-          shopt -u nullglob
-
-          # Filter to regular files only
-          regular=()
-          for file in "${files[@]}"; do
-            [[ -f "$file" ]] && regular+=("$file")
-          done
-
-          if [[ ${#regular[@]} -eq 0 ]]; then
-            echo "No release assets found" >&2
-            exit 1
-          fi
-
-          gh release upload "$RELEASE_TAG" "${regular[@]}" --clobber
-
-      - name: Upload workflow artifact (debug)
-        if: ${{ steps.target-filter.outputs.skip == 'false' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: lexed-${{ matrix.platform }}
-          path: |
-            release/**
-            dist/**
-          if-no-files-found: error
+  # Downstream cascade: lexed is a leaf (no consumers depend on it),
+  # so no notify-downstreams step. If a future consumer pins lexed
+  # artifacts, add a notify-downstreams job here that fires
+  # repository_dispatch upstream-released to those repos (see
+  # arthur-debert/release/docs/lex-release-cascade.md §Layer 2).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,23 +7,21 @@
 # `gh workflow run release.yml -f version=<X>` — the reusable workflow's
 # prepare-release-npm action then bumps package.json, commits, tags,
 # pushes, and drives the rest (build per arch, sign via electron-
-# builder's CSC_LINK path, GH release with .dmg + .AppImage assets).
+# builder's CSC_LINK path, notarize, GH release).
 #
 # Migration history: replaces the previous in-tree per-platform matrix
-# build (with custom smoke tests). See arthur-debert/release#65 for the
-# canonical electron-app workflow + #43 for the per-stack rollout
-# tracking issue.
+# build. See arthur-debert/release#65 (slice 1) + #66 (slice 1.5:
+# notarize override + smoke convention) for the canonical workflow.
 #
-# Slice-1 caveats (carried from the canonical workflow):
-# - Windows builds produce unsigned binaries (code-signing slice 3).
-# - macOS notarization is gated by `build.mac.notarize` in package.json
-#   (currently false → signing happens but notarization is skipped).
-#   Flip to `true` to enable notarization once the ASC_API_KEY_*
-#   secrets are in place.
-# - Per-platform smoke tests (linux xvfb-run launch, macOS .app spawn,
-#   etc.) ARE dropped in this slice. Slice 2 of electron-app folds an
-#   `e2e` job into the canonical workflow; until then, smoke is
-#   covered by the pre-commit / test.yml flow locally.
+# Slice-1.5 caveats this caller carries forward:
+# - Windows builds produce unsigned binaries (code-signing → slice 3).
+# - QuickLook plugin (`Contents/PlugIns/LexQuickLook.appex`) is not
+#   yet re-signed via electron-builder's `afterPack` hook. The released
+#   `.app` bundle signs and notarizes correctly, but the embedded
+#   QuickLook extension is unsigned, so macOS Quick Look integration
+#   won't load on user machines. Tracking: TBD follow-up issue —
+#   port the previous in-tree re-sign step to an afterPack JS hook
+#   in package.json.
 
 name: Release LexEd
 
@@ -51,6 +49,15 @@ jobs:
       submodules: true
       changelog-path: CHANGELOG.md
       node-version: '22'
+      # electron-builder directories.output → "release" per
+      # package.json. The canonical workflow defaults to "dist".
+      output-dir: release
+      # Force-enable macOS notarization in CI, overriding
+      # `build.mac.notarize: false` in package.json (which is kept
+      # `false` for local-dev where ASC keys aren't configured).
+      # Requires ASC_API_KEY_BASE64 / _ID / _ISSUER_ID secrets to
+      # be set on this repo; the workflow fails fast if they aren't.
+      notarize: 'true'
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
@@ -58,9 +65,3 @@ jobs:
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
-
-  # Downstream cascade: lexed is a leaf (no consumers depend on it),
-  # so no notify-downstreams step. If a future consumer pins lexed
-  # artifacts, add a notify-downstreams job here that fires
-  # repository_dispatch upstream-released to those repos (see
-  # arthur-debert/release/docs/lex-release-cascade.md §Layer 2).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@
 #
 # Slice-1.5 caveats this caller carries forward:
 # - Windows builds produce unsigned binaries (code-signing → slice 3).
-# - QuickLook plugin (`Contents/PlugIns/LexQuickLook.appex`) is not
-#   yet re-signed via electron-builder's `afterPack` hook. The released
-#   `.app` bundle signs and notarizes correctly, but the embedded
-#   QuickLook extension is unsigned, so macOS Quick Look integration
-#   won't load on user machines. Tracking: TBD follow-up issue —
-#   port the previous in-tree re-sign step to an afterPack JS hook
-#   in package.json.
+#
+# QuickLook plugin signing: handled via the `scripts/electron-after-
+# pack.js` afterPack hook wired in package.json (resolves
+# arthur-debert/release#67). The hook signs the embedded
+# Contents/PlugIns/LexQuickLook.appex BEFORE electron-builder signs
+# the parent .app — necessary because electron-builder's sign pass
+# doesn't recurse into PlugIns/*.appex.
 
 name: Release LexEd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
       windows-archs: x64
       submodules: true
       changelog-path: CHANGELOG.md
-      node-version: '22'
+      # Pin to match .github/workflows/test.yml — release artifacts
+      # should build under the same Node patch CI validated.
+      node-version: '22.18.0'
       # electron-builder directories.output → "release" per
       # package.json. The canonical workflow defaults to "dist".
       output-dir: release

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
         "to": "assets/logo-full.png"
       }
     ],
-    "afterPack": "./scripts/electron-after-pack.js"
+    "afterPack": "./scripts/electron-after-pack.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -246,7 +246,8 @@
         "from": "comms/assets/logo-full.png",
         "to": "assets/logo-full.png"
       }
-    ]
+    ],
+    "afterPack": "./scripts/electron-after-pack.js"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/electron-after-pack.js
+++ b/scripts/electron-after-pack.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-env node */
 /**
  * electron-builder afterPack hook — sign embedded helper bundles that
  * electron-builder's own signing pass doesn't recurse into.
@@ -97,7 +98,7 @@ exports.default = async function afterPack(context) {
   // same runner (rare on ephemeral runners, defensive otherwise).
   try {
     execSync(`security delete-keychain "${keychainPath}"`, { stdio: 'ignore' });
-  } catch (_) { /* ignore */ }
+  } catch { /* ignore — keychain may not exist on first run */ }
 
   execSync(`security create-keychain -p "${keychainPassword}" "${keychainPath}"`);
   execSync(`security set-keychain-settings -lut 3600 "${keychainPath}"`);

--- a/scripts/electron-after-pack.js
+++ b/scripts/electron-after-pack.js
@@ -1,0 +1,159 @@
+'use strict';
+/**
+ * electron-builder afterPack hook — sign embedded helper bundles that
+ * electron-builder's own signing pass doesn't recurse into.
+ *
+ * Why this exists
+ * ---------------
+ * lexed embeds Contents/PlugIns/LexQuickLook.appex into the .app via
+ * `extraFiles` in package.json. electron-builder's macOS signing pass
+ * signs the parent .app but does NOT descend into PlugIns/*.appex, so
+ * the embedded extension ships unsigned and macOS refuses to load it.
+ * Quick Look integration for `.lex` / `.lexd` files in Finder /
+ * `qlmanage` silently breaks at install time on user machines.
+ *
+ * afterPack is the canonical electron-builder lifecycle hook for this:
+ * it runs BETWEEN pack and sign, so we sign the appex first and
+ * electron-builder's later sign of the parent .app seals the appex's
+ * signature in cleanly. Doing the equivalent work AFTER electron-
+ * builder finished would invalidate the parent .app's notarization
+ * (the historical workaround in lexed's old release.yml worked
+ * because notarization was a separate step; in the canonical
+ * arthur-debert/release workflow notarization is inline with build).
+ *
+ * Why the temp-keychain dance
+ * ---------------------------
+ * electron-builder sets up its temp keychain AT SIGN TIME, which is
+ * AFTER afterPack runs. So we can't reuse it from here. We set up
+ * our own dedicated keychain to source the Developer ID Application
+ * identity, then sign the appex with `codesign --keychain <ours>`.
+ * electron-builder's later pass creates its own keychain and signs
+ * the parent .app — that's fine, the appex signature is already
+ * embedded in the file by then.
+ *
+ * Env contract (set by arthur-debert/release/.github/workflows/
+ * electron-app.yml's slice-1.5 credentials decode step):
+ *   CSC_LINK            path to a .p12 file (set by the workflow)
+ *   CSC_KEY_PASSWORD    password for the .p12
+ *
+ * Skips gracefully (logs and returns) when env vars aren't set —
+ * local-dev builds without signing credentials still work.
+ *
+ * Refs:
+ *   arthur-debert/release#67 — issue
+ *   arthur-debert/release#66 — slice 1.5 (where post-build was
+ *     correctly rejected in favor of afterPack)
+ *   electron-builder docs — https://www.electron.build/configuration/configuration#afterpack
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync, execFileSync } = require('child_process');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+
+  const cscLink = process.env.CSC_LINK;
+  const cscPassword = process.env.CSC_KEY_PASSWORD || '';
+  if (!cscLink) {
+    console.log('[afterPack] CSC_LINK not set — skipping QuickLook appex signing (local-dev build).');
+    return;
+  }
+
+  const tempDir = process.env.RUNNER_TEMP || '/tmp';
+
+  // CSC_LINK can be a file path (workflow's decode step writes one),
+  // a `data:application/x-pkcs12;base64,...` URI, or a bare base64
+  // string. Normalize to a file path on disk.
+  let certPath;
+  if (fs.existsSync(cscLink)) {
+    certPath = cscLink;
+  } else if (cscLink.startsWith('data:')) {
+    const b64 = cscLink.split(',')[1] || '';
+    certPath = path.join(tempDir, 'after-pack-cert.p12');
+    fs.writeFileSync(certPath, Buffer.from(b64, 'base64'));
+  } else {
+    certPath = path.join(tempDir, 'after-pack-cert.p12');
+    fs.writeFileSync(certPath, Buffer.from(cscLink, 'base64'));
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  const appexPath = path.join(appPath, 'Contents', 'PlugIns', 'LexQuickLook.appex');
+
+  if (!fs.existsSync(appexPath)) {
+    console.log(`[afterPack] ${appexPath} not present — skipping`);
+    return;
+  }
+
+  // Dedicated temp keychain for this hook. electron-builder's own
+  // keychain is set up at sign time (after this hook), so it isn't
+  // available to us.
+  const keychainPath = path.join(tempDir, 'after-pack.keychain-db');
+  const keychainPassword = crypto.randomBytes(16).toString('hex');
+
+  // Idempotent: remove a stale keychain from a previous run on the
+  // same runner (rare on ephemeral runners, defensive otherwise).
+  try {
+    execSync(`security delete-keychain "${keychainPath}"`, { stdio: 'ignore' });
+  } catch (_) { /* ignore */ }
+
+  execSync(`security create-keychain -p "${keychainPassword}" "${keychainPath}"`);
+  execSync(`security set-keychain-settings -lut 3600 "${keychainPath}"`);
+  execSync(`security unlock-keychain -p "${keychainPassword}" "${keychainPath}"`);
+  execSync(`security import "${certPath}" -k "${keychainPath}" -P "${cscPassword}" -T /usr/bin/codesign`);
+  execSync(`security set-key-partition-list -S apple-tool:,apple: -s -k "${keychainPassword}" "${keychainPath}"`);
+
+  // Append the new keychain to the user's search list — codesign
+  // won't find identities without this. Preserve the existing
+  // entries (don't replace) so other tooling on the runner keeps
+  // working.
+  const existingKeychains = execSync('security list-keychains -d user', { encoding: 'utf-8' })
+    .split('\n')
+    .map(line => line.trim().replace(/^"|"$/g, ''))
+    .filter(Boolean);
+  const searchList = [keychainPath, ...existingKeychains].map(k => `"${k}"`).join(' ');
+  execSync(`security list-keychains -d user -s ${searchList}`);
+
+  // Find the Developer ID Application identity in our keychain.
+  const findOut = execSync(
+    `security find-identity -v -p codesigning "${keychainPath}"`,
+    { encoding: 'utf-8' }
+  );
+  const match = findOut.match(/"(Developer ID Application[^"]+)"/);
+  if (!match) {
+    throw new Error(
+      `[afterPack] no Developer ID Application identity in keychain. find-identity output:\n${findOut}`
+    );
+  }
+  const identity = match[1];
+
+  // Sign the appex with the same hardening flags electron-builder
+  // will use for the parent .app (--options runtime --timestamp +
+  // entitlements). codesign embeds the signature INTO the file, so
+  // when electron-builder signs the parent .app later, the appex
+  // signature is sealed in naturally.
+  const entitlementsPath = path.resolve('resources/entitlements.mac.plist');
+  if (!fs.existsSync(entitlementsPath)) {
+    throw new Error(`[afterPack] entitlements file not found at ${entitlementsPath}`);
+  }
+
+  console.log(`[afterPack] signing ${appexPath} with ${identity}`);
+  execFileSync('codesign', [
+    '--force',
+    '--sign', identity,
+    '--options', 'runtime',
+    '--timestamp',
+    '--entitlements', entitlementsPath,
+    '--keychain', keychainPath,
+    appexPath,
+  ], { stdio: 'inherit' });
+
+  // Verify before declaring success — `codesign --verify` surfaces
+  // problems that the sign step itself reports as success (broken
+  // entitlements, missing required keys, etc.).
+  execFileSync('codesign', ['--verify', '--verbose', appexPath], { stdio: 'inherit' });
+
+  console.log('[afterPack] QuickLook appex signed and verified');
+};

--- a/scripts/electron-after-pack.mjs
+++ b/scripts/electron-after-pack.mjs
@@ -1,5 +1,3 @@
-'use strict';
-/* eslint-env node */
 /**
  * electron-builder afterPack hook — sign embedded helper bundles that
  * electron-builder's own signing pass doesn't recurse into.
@@ -32,6 +30,13 @@
  * the parent .app — that's fine, the appex signature is already
  * embedded in the file by then.
  *
+ * Why .mjs
+ * --------
+ * lexed's eslint.config.js has a `scripts/**/*.mjs` block that
+ * provides Node globals + ESM sourceType. Naming the file `.mjs`
+ * picks up that block automatically and avoids an eslint-config
+ * edit. electron-builder 22+ supports ESM afterPack hooks natively.
+ *
  * Env contract (set by arthur-debert/release/.github/workflows/
  * electron-app.yml's slice-1.5 credentials decode step):
  *   CSC_LINK            path to a .p12 file (set by the workflow)
@@ -41,70 +46,72 @@
  * local-dev builds without signing credentials still work.
  *
  * Refs:
- *   arthur-debert/release#67 — issue
+ *   arthur-debert/release#67 — issue (resolved by this hook)
  *   arthur-debert/release#66 — slice 1.5 (where post-build was
  *     correctly rejected in favor of afterPack)
  *   electron-builder docs — https://www.electron.build/configuration/configuration#afterpack
  */
 
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
-const { execSync, execFileSync } = require('child_process');
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { execSync, execFileSync } from 'node:child_process'
 
-exports.default = async function afterPack(context) {
-  if (context.electronPlatformName !== 'darwin') return;
+export default async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return
 
-  const cscLink = process.env.CSC_LINK;
-  const cscPassword = process.env.CSC_KEY_PASSWORD || '';
+  const cscLink = process.env.CSC_LINK
+  const cscPassword = process.env.CSC_KEY_PASSWORD || ''
   if (!cscLink) {
-    console.log('[afterPack] CSC_LINK not set — skipping QuickLook appex signing (local-dev build).');
-    return;
+    console.log('[afterPack] CSC_LINK not set — skipping QuickLook appex signing (local-dev build).')
+    return
   }
 
-  const tempDir = process.env.RUNNER_TEMP || '/tmp';
+  const tempDir = process.env.RUNNER_TEMP || '/tmp'
 
   // CSC_LINK can be a file path (workflow's decode step writes one),
   // a `data:application/x-pkcs12;base64,...` URI, or a bare base64
   // string. Normalize to a file path on disk.
-  let certPath;
+  let certPath
   if (fs.existsSync(cscLink)) {
-    certPath = cscLink;
+    certPath = cscLink
   } else if (cscLink.startsWith('data:')) {
-    const b64 = cscLink.split(',')[1] || '';
-    certPath = path.join(tempDir, 'after-pack-cert.p12');
-    fs.writeFileSync(certPath, Buffer.from(b64, 'base64'));
+    const b64 = cscLink.split(',')[1] || ''
+    certPath = path.join(tempDir, 'after-pack-cert.p12')
+    fs.writeFileSync(certPath, Buffer.from(b64, 'base64'))
   } else {
-    certPath = path.join(tempDir, 'after-pack-cert.p12');
-    fs.writeFileSync(certPath, Buffer.from(cscLink, 'base64'));
+    certPath = path.join(tempDir, 'after-pack-cert.p12')
+    fs.writeFileSync(certPath, Buffer.from(cscLink, 'base64'))
   }
 
-  const appName = context.packager.appInfo.productFilename;
-  const appPath = path.join(context.appOutDir, `${appName}.app`);
-  const appexPath = path.join(appPath, 'Contents', 'PlugIns', 'LexQuickLook.appex');
+  const appName = context.packager.appInfo.productFilename
+  const appPath = path.join(context.appOutDir, `${appName}.app`)
+  const appexPath = path.join(appPath, 'Contents', 'PlugIns', 'LexQuickLook.appex')
 
   if (!fs.existsSync(appexPath)) {
-    console.log(`[afterPack] ${appexPath} not present — skipping`);
-    return;
+    console.log(`[afterPack] ${appexPath} not present — skipping`)
+    return
   }
 
   // Dedicated temp keychain for this hook. electron-builder's own
   // keychain is set up at sign time (after this hook), so it isn't
   // available to us.
-  const keychainPath = path.join(tempDir, 'after-pack.keychain-db');
-  const keychainPassword = crypto.randomBytes(16).toString('hex');
+  const keychainPath = path.join(tempDir, 'after-pack.keychain-db')
+  const keychainPassword = crypto.randomBytes(16).toString('hex')
 
   // Idempotent: remove a stale keychain from a previous run on the
   // same runner (rare on ephemeral runners, defensive otherwise).
   try {
-    execSync(`security delete-keychain "${keychainPath}"`, { stdio: 'ignore' });
-  } catch { /* ignore — keychain may not exist on first run */ }
+    execSync(`security delete-keychain "${keychainPath}"`, { stdio: 'ignore' })
+  } catch {
+    // ignore — keychain may not exist on first run
+  }
 
-  execSync(`security create-keychain -p "${keychainPassword}" "${keychainPath}"`);
-  execSync(`security set-keychain-settings -lut 3600 "${keychainPath}"`);
-  execSync(`security unlock-keychain -p "${keychainPassword}" "${keychainPath}"`);
-  execSync(`security import "${certPath}" -k "${keychainPath}" -P "${cscPassword}" -T /usr/bin/codesign`);
-  execSync(`security set-key-partition-list -S apple-tool:,apple: -s -k "${keychainPassword}" "${keychainPath}"`);
+  execSync(`security create-keychain -p "${keychainPassword}" "${keychainPath}"`)
+  execSync(`security set-keychain-settings -lut 3600 "${keychainPath}"`)
+  execSync(`security unlock-keychain -p "${keychainPassword}" "${keychainPath}"`)
+  execSync(`security import "${certPath}" -k "${keychainPath}" -P "${cscPassword}" -T /usr/bin/codesign`)
+  execSync(`security set-key-partition-list -S apple-tool:,apple: -s -k "${keychainPassword}" "${keychainPath}"`)
 
   // Append the new keychain to the user's search list — codesign
   // won't find identities without this. Preserve the existing
@@ -113,34 +120,34 @@ exports.default = async function afterPack(context) {
   const existingKeychains = execSync('security list-keychains -d user', { encoding: 'utf-8' })
     .split('\n')
     .map(line => line.trim().replace(/^"|"$/g, ''))
-    .filter(Boolean);
-  const searchList = [keychainPath, ...existingKeychains].map(k => `"${k}"`).join(' ');
-  execSync(`security list-keychains -d user -s ${searchList}`);
+    .filter(Boolean)
+  const searchList = [keychainPath, ...existingKeychains].map(k => `"${k}"`).join(' ')
+  execSync(`security list-keychains -d user -s ${searchList}`)
 
   // Find the Developer ID Application identity in our keychain.
   const findOut = execSync(
     `security find-identity -v -p codesigning "${keychainPath}"`,
     { encoding: 'utf-8' }
-  );
-  const match = findOut.match(/"(Developer ID Application[^"]+)"/);
+  )
+  const match = findOut.match(/"(Developer ID Application[^"]+)"/)
   if (!match) {
     throw new Error(
       `[afterPack] no Developer ID Application identity in keychain. find-identity output:\n${findOut}`
-    );
+    )
   }
-  const identity = match[1];
+  const identity = match[1]
 
   // Sign the appex with the same hardening flags electron-builder
   // will use for the parent .app (--options runtime --timestamp +
   // entitlements). codesign embeds the signature INTO the file, so
   // when electron-builder signs the parent .app later, the appex
   // signature is sealed in naturally.
-  const entitlementsPath = path.resolve('resources/entitlements.mac.plist');
+  const entitlementsPath = path.resolve('resources/entitlements.mac.plist')
   if (!fs.existsSync(entitlementsPath)) {
-    throw new Error(`[afterPack] entitlements file not found at ${entitlementsPath}`);
+    throw new Error(`[afterPack] entitlements file not found at ${entitlementsPath}`)
   }
 
-  console.log(`[afterPack] signing ${appexPath} with ${identity}`);
+  console.log(`[afterPack] signing ${appexPath} with ${identity}`)
   execFileSync('codesign', [
     '--force',
     '--sign', identity,
@@ -149,12 +156,12 @@ exports.default = async function afterPack(context) {
     '--entitlements', entitlementsPath,
     '--keychain', keychainPath,
     appexPath,
-  ], { stdio: 'inherit' });
+  ], { stdio: 'inherit' })
 
   // Verify before declaring success — `codesign --verify` surfaces
   // problems that the sign step itself reports as success (broken
   // entitlements, missing required keys, etc.).
-  execFileSync('codesign', ['--verify', '--verbose', appexPath], { stdio: 'inherit' });
+  execFileSync('codesign', ['--verify', '--verbose', appexPath], { stdio: 'inherit' })
 
-  console.log('[afterPack] QuickLook appex signed and verified');
-};
+  console.log('[afterPack] QuickLook appex signed and verified')
+}

--- a/scripts/electron-after-pack.mjs
+++ b/scripts/electron-after-pack.mjs
@@ -32,10 +32,13 @@
  *
  * Why .mjs
  * --------
- * lexed's eslint.config.js has a `scripts/**/*.mjs` block that
- * provides Node globals + ESM sourceType. Naming the file `.mjs`
- * picks up that block automatically and avoids an eslint-config
- * edit. electron-builder 22+ supports ESM afterPack hooks natively.
+ * lexed's eslint.config.js has a `scripts` glob that matches `.mjs`
+ * files and provides Node globals + ESM sourceType. Naming the file
+ * `.mjs` picks up that block automatically and avoids an eslint-
+ * config edit. electron-builder 22+ supports ESM afterPack hooks
+ * natively. (The actual glob lives in eslint.config.js — not
+ * written here because a literal block-comment-escape sequence
+ * would prematurely close this JSDoc.)
  *
  * Env contract (set by arthur-debert/release/.github/workflows/
  * electron-app.yml's slice-1.5 credentials decode step):

--- a/scripts/release/trigger-release
+++ b/scripts/release/trigger-release
@@ -1,38 +1,44 @@
 #!/usr/bin/env bash
-# trigger-release <new-version> — kick off a release by creating and pushing
-# the `v<new-version>` git tag.
+# trigger-release <new-version> — fire .github/workflows/release.yml
+# via `workflow_dispatch` with the requested version as input.
 #
 # Layer 0 release primitive — see lex-fmt/lex#640. Sister scripts:
 #   - get-current-version
 #   - get-commits-since-release
 #   - update-release
 #
-# Release strategy: **tag-push**. This repo's release CI workflow is gated on
-# `on: push: tags: [v*]`, so pushing the tag is the trigger. (Contrast with
-# `workflow-dispatch` repos where the orchestrator instead calls
-# `gh workflow run release.yml`.)
+# Release strategy: **workflow_dispatch**. lexed's release.yml is a
+# thin caller into arthur-debert/release/.github/workflows/electron-
+# app.yml@v1; the reusable workflow's prepare-release-npm action
+# handles the bump + commit + tag + push internally. This primitive's
+# only job is to fire the dispatch with the version input — the tag
+# itself is created by the workflow at release time.
 #
-# Called by the higher-layer release orchestrator after the version-bump PR
-# has been merged to `main` and `main` has been fast-forwarded locally. The
-# tag is placed on whatever commit `HEAD` currently points at — the caller is
-# responsible for ensuring `HEAD` is the merged bump commit.
+# Migration history: previously this script created and pushed an
+# annotated git tag, and release.yml ran on `on: push: tags: [v*]`.
+# After the electron-app rollout (arthur-debert/release#65), release.yml
+# moved to workflow_dispatch (matching `lex`'s pattern) so the
+# canonical reusable workflow can drive the bump itself, with resume-
+# on-existing-tag semantics that compose with the cross-repo
+# orchestrator's pre-bumped flow.
+#
+# Called by the higher-layer release orchestrator (release-lex / the
+# cascade-handler reusable workflow) after the version-bump PR has
+# been merged to `main`. The caller is responsible for ensuring
+# `main` is on the bump commit before invoking; the dispatch fires
+# against `main` and the workflow checks out from there.
 #
 # Usage:
-#   trigger-release 0.10.1
+#   trigger-release 0.10.2
 #
 # Exit codes:
-#   0  tag created and pushed
-#   1  tag already exists (locally or on origin) — caller must resolve
+#   0  workflow dispatch fired
 #   2  bad usage / malformed version
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$REPO_ROOT"
-
 usage() {
   echo "Usage: $(basename "$0") <new-version>" >&2
-  echo "  new-version   Bare semver string, e.g. 0.10.1 (no leading v)" >&2
+  echo "  new-version   Bare semver string, e.g. 0.10.2 (no leading v)" >&2
 }
 
 if [[ $# -ne 1 ]]; then
@@ -41,54 +47,12 @@ if [[ $# -ne 1 ]]; then
 fi
 
 NEW_VERSION="$1"
-if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "error: version must be X.Y.Z (got: $NEW_VERSION)" >&2
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([0-9A-Za-z.-]*)$ ]]; then
+  echo "error: version must be X.Y.Z[-PRERELEASE] (got: $NEW_VERSION)" >&2
   exit 2
 fi
 
-TAG="v$NEW_VERSION"
-
-# Refuse to create a tag that already exists locally. If a previous run left
-# the tag behind, the caller can `git tag -d $TAG && git push --delete
-# origin $TAG` or re-use the existing one explicitly — we don't guess.
-if git rev-parse "$TAG" >/dev/null 2>&1; then
-  echo "error: tag $TAG already exists locally — delete it or pick a new version" >&2
-  exit 1
-fi
-
-# Also check origin so we fail with a clear message instead of a generic
-# `git push` rejection if the tag exists remotely but not locally.
-if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-  echo "error: tag $TAG already exists on origin — pick a new version" >&2
-  exit 1
-fi
-
-# Extract release notes for $NEW_VERSION from CHANGELOG.md (everything
-# between this version's `## v$NEW_VERSION` header and the next `## ` header).
-# The release workflow reads the tag annotation via `git tag -l
-# --format='%(contents)'` and uses it verbatim as the GitHub release body,
-# so the tag MUST be annotated (-a). If no section is found we fall back
-# to a bare "Release $TAG" message rather than failing — the orchestrator
-# may have its own reasons for tagging without a changelog entry, and a
-# release with a thin body beats no release at all.
-CHANGELOG="$REPO_ROOT/CHANGELOG.md"
-NOTES=""
-if [[ -f "$CHANGELOG" ]]; then
-  NOTES=$(awk -v ver="v$NEW_VERSION" '
-    $0 ~ "^## " ver "([^0-9A-Za-z.]|$)" { in_section = 1; next }
-    in_section && /^## / { exit }
-    in_section { print }
-  ' "$CHANGELOG")
-fi
-if [[ -z "${NOTES//[[:space:]]/}" ]]; then
-  NOTES="Release $TAG"
-fi
-
-echo "Tagging $TAG on $(git rev-parse --short HEAD)..."
-# Annotated tag (not lightweight): release.yml reads `%(contents)` from the
-# tag object to populate the GitHub Release body. Lightweight tags would
-# fall through to the commit message.
-git tag -a "$TAG" -m "$NOTES"
-echo "Pushing $TAG to origin..."
-git push origin "$TAG"
-echo "Done. CI should pick it up shortly."
+echo "Dispatching release.yml with version=$NEW_VERSION..."
+gh workflow run release.yml --ref main -f version="$NEW_VERSION"
+echo "Dispatched. The release workflow will bump package.json, tag, push, build, sign, and publish. Watch with:"
+echo "  gh run watch --repo lex-fmt/lexed"

--- a/scripts/release/trigger-release
+++ b/scripts/release/trigger-release
@@ -36,6 +36,14 @@
 #   2  bad usage / malformed version
 set -euo pipefail
 
+# Locate the repo root so `gh` infers the right repository from the git
+# remote regardless of where the orchestrator calls this script from.
+# The orchestrator (release-lex) invokes by absolute path; without the
+# `cd`, `gh workflow run` would either use the wrong repo or fail.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
 usage() {
   echo "Usage: $(basename "$0") <new-version>" >&2
   echo "  new-version   Bare semver string, e.g. 0.10.2 (no leading v)" >&2
@@ -46,9 +54,15 @@ if [[ $# -ne 1 ]]; then
   exit 2
 fi
 
+# Strict semver: MAJOR.MINOR.PATCH with optional `-PRERELEASE` suffix
+# (matches prepare-release-npm's validation exactly). The previous
+# pattern allowed `1.2.3foo` / `1.2.3-` / `1.2.3..` because the suffix
+# was a loose `[0-9A-Za-z.-]*` — those would dispatch the workflow
+# with a version that update-release would later reject. Fail here
+# instead of two steps deep.
 NEW_VERSION="$1"
-if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([0-9A-Za-z.-]*)$ ]]; then
-  echo "error: version must be X.Y.Z[-PRERELEASE] (got: $NEW_VERSION)" >&2
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "error: version must be MAJOR.MINOR.PATCH[-PRERELEASE] (got: $NEW_VERSION)" >&2
   exit 2
 fi
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Packaged-binary smoke test for the canonical electron-app workflow.
+#
+# Convention-based hook detected by
+# arthur-debert/release/.github/workflows/electron-app.yml — it
+# `hashFiles('scripts/smoke.sh')` and runs this script after build,
+# before artifact upload, when the file is present.
+#
+# Goal: catch "ships but won't launch" regressions — missing bundled
+# lexd-lsp, broken renderer mount, crash-on-startup, Windows path
+# quirks. Wraps Playwright's `packaged` project (the same test surface
+# the previous in-tree release.yml exercised), so any tests that
+# survived in tests/e2e/ with `--project=packaged` keep running here.
+#
+# Env vars provided by the canonical workflow:
+#   PLATFORM     mac | linux | windows
+#   ARCH         arm64 | x64 | ...
+#   PACKAGE_DIR  electron-builder directories.output (here: `release`)
+#
+# Env vars Playwright reads (matches the old release.yml's shape):
+#   PACKAGED_APP_PATH    absolute path to the packaged executable
+#   E2E_SKIP_BUILD=1     don't re-pack inside Playwright globalSetup
+#                        (electron-builder already produced the build).
+#
+# Smoke runs AFTER electron-builder signing AND notarization — keep
+# the script read-only (launch + check); ANY artifact modification
+# here invalidates the notarization.
+
+set -euo pipefail
+
+case "${PLATFORM}" in
+  mac)
+    PACKAGED_APP_PATH="${PACKAGE_DIR}/mac-${ARCH}/LexEd.app/Contents/MacOS/LexEd"
+    SMOKE_PREFIX=()
+    ;;
+  linux)
+    # electron-builder produces `linux-unpacked/` for single-arch
+    # linux builds (no arch suffix on x64). If a future arch like
+    # arm64 is enabled, this branch would need PLATFORM/ARCH
+    # composition matching electron-builder's per-arch dir naming.
+    PACKAGED_APP_PATH="${PACKAGE_DIR}/linux-unpacked/lexed"
+    # `xvfb-run -a` provides a headless X11 display so the packaged
+    # Electron binary can open its window during the smoke run on a
+    # Linux runner without a real display.
+    SMOKE_PREFIX=(xvfb-run -a)
+    ;;
+  windows)
+    PACKAGED_APP_PATH="${PACKAGE_DIR}/win-unpacked/LexEd.exe"
+    SMOKE_PREFIX=()
+    ;;
+  *)
+    echo "smoke.sh: unknown PLATFORM='${PLATFORM:-}' (expected mac|linux|windows)" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -e "${PACKAGED_APP_PATH}" ]; then
+  echo "smoke.sh: packaged binary not found at ${PACKAGED_APP_PATH}" >&2
+  echo "smoke.sh: expected layout for PLATFORM=${PLATFORM} ARCH=${ARCH} PACKAGE_DIR=${PACKAGE_DIR}" >&2
+  echo "smoke.sh: contents of PACKAGE_DIR:" >&2
+  ls -la "${PACKAGE_DIR}" >&2 || true
+  exit 1
+fi
+
+export PACKAGED_APP_PATH
+export E2E_SKIP_BUILD=1
+
+echo "smoke.sh: PLATFORM=${PLATFORM} ARCH=${ARCH} → ${PACKAGED_APP_PATH}"
+echo "smoke.sh: running Playwright packaged project"
+
+"${SMOKE_PREFIX[@]}" npx playwright test --project=packaged


### PR DESCRIPTION
Migrates lexed's release pipeline onto the canonical electron-app reusable workflow shipped in [arthur-debert/release#65](https://github.com/arthur-debert/release/pull/65).

## What changes

| File | Before | After |
|---|---|---|
| `.github/workflows/release.yml` | ~317 lines, per-platform matrix + smoke tests + inline GH release | ~67 lines, thin caller into `arthur-debert/release/.github/workflows/electron-app.yml@v1` |
| `scripts/release/trigger-release` | ~94 lines, creates + pushes annotated tag, extracts changelog notes inline | ~58 lines, fires `gh workflow run release.yml -f version=X` |

Net: **-372 / +85** lines.

### Trigger-model shift

`release.yml` moves from `on: push: tags: [v*]` to `workflow_dispatch` with a `version` input. This matches the contract the cross-repo cascade-handler (`arthur-debert/release/.github/workflows/cascade-handler.yml`) expects from per-stack release workflows. `lex`'s release.yml already uses this model — we're aligning lexed.

### Release-flow ownership shift

| Step | Before (tag-push) | After (workflow_dispatch) |
|---|---|---|
| Bump `package.json` | the `update-release` primitive (run by orchestrator before tagging) | the workflow's `prepare-release-npm` action |
| Create + push tag | `trigger-release` primitive | the workflow's `prepare-release-npm` action |
| Resume-on-existing-tag | manual recovery | built into `prepare-release-npm` |

The cross-repo orchestrator (`release-lex`) and cascade-handler call `update-release` then `trigger-release` — that contract is unchanged. The workflow now handles the tag-pushing internally.

## What's lost (intentional)

- **Per-platform smoke tests** (linux `xvfb-run` app launch, macOS `.app` spawn, windows `.exe` launch). The canonical electron-app slice 1 ships build + sign + release only; slice 2 of [#43](https://github.com/arthur-debert/release/issues/43) will fold an `e2e` job back into the canonical workflow. Until then, smoke is covered locally by the pre-commit + test.yml flow.
- **Inline GH release creation step**. The canonical workflow's `release` job handles this (with resume-on-existing semantics, so re-firing is safe).

## What's gained

- **Correct macOS signing**: electron-builder's `CSC_LINK` path signs the `.app` before embedding into the `.dmg`. The previous in-tree shape would have shipped DMGs with **unsigned** app bundles (caught during review on arthur-debert/release#65 — see [the comment](https://github.com/arthur-debert/release/pull/65)).
- **Resume-safe releases**. The reusable workflow's `prepare-release-npm` action validates the tag-vs-manifest invariant if the tag already exists, and skips bump steps cleanly. A failed mid-flight release can be re-dispatched without manual git surgery.
- **Fix-once-propagate**: future fixes to the electron-app pipeline land in `arthur-debert/release` and lexed picks them up via `@v1`. No per-repo edits when the canonical evolves.

## Caveats (carried from the canonical, not lexed-specific)

These will lift as later slices land:

- **macOS notarization** is gated by `build.mac.notarize` in `package.json` (currently `false`). With the secrets configured, signing still happens; notarization is skipped. Flip the flag to `true` to enable.
- **Windows builds produce unsigned binaries** (Windows code-signing is slice 3 of electron-app).
- **Auto-updater feed** (`latest-mac.yml`, etc.) is not yet generated — slice 2.

## Cascade compatibility

The Layer-2 cascade is **unchanged** from the cascade's perspective. `on-upstream-released.yml` still calls `scripts/release/trigger-release` — that primitive now dispatches a workflow run instead of pushing a tag, but the call shape is identical.

## How to test

The next release of lexed (manual or cascade-triggered) will exercise the new path end-to-end. To do a manual smoke:

```
gh workflow run release.yml --ref main -f version=<NEXT> --repo lex-fmt/lexed
gh run watch --repo lex-fmt/lexed
```

The reusable workflow's prepare step does the bump + tag + push, then the build matrix runs per arch. Watch for sign-success in the macOS build job log.

## Refs

- [`arthur-debert/release#65`](https://github.com/arthur-debert/release/pull/65) — canonical electron-app slice 1
- [`arthur-debert/release#43`](https://github.com/arthur-debert/release/issues/43) — electron-app rollout tracking
- [`arthur-debert/release/docs/lex-release-cascade.md`](https://github.com/arthur-debert/release/blob/main/docs/lex-release-cascade.md)
- [lex-fmt/lex#640](https://github.com/lex-fmt/lex/issues/640) — cascade rollout history

🤖 Generated with [Claude Code](https://claude.com/claude-code)