### PR TITLE
chore: add [Unreleased] section to unblock canonical workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Add `## [Unreleased]` Keep-a-Changelog section so the canonical
+  `arthur-debert/release/.github/workflows/electron-app.yml@v1`
+  release pipeline (called via `release.yml`) can clear its
+  `prepare-release-npm` pre-flight, which expects this format. No
+  product-facing changes in this entry — it unblocks the first
+  end-to-end validation run of the canonical release workflow
+  against lexed.
+
 ## v0.10.2 (2026-05-18)
 
 ## v0.10.1 (2026-05-17)


### PR DESCRIPTION
Refs arthur-debert/release#122 (validation: USE-and-succeed test per canonical artifact).

## Why

The thin-caller `release.yml` (merged 2026-05-18) calls `arthur-debert/release/.github/workflows/electron-app.yml@v1`, whose `prepare-release-npm` action requires Keep-a-Changelog `## [Unreleased]` format.

The previous header style (`## v0.10.2 (date)`) trips that gate — verified by the 2026-05-18 dispatch (run 26058453527) that failed at "Prepare release (npm)" with:

```
##[error]CHANGELOG section [Unreleased] is missing or empty in CHANGELOG.md
##[error]Add a brief entry under ## [Unreleased] describing this release before re-running.
```

The canonical `electron-app.yml@v1` has **never** produced a successful lexed release; this CHANGELOG mismatch is why. This PR unblocks the first end-to-end validation run.

## What this PR does NOT do

- Does NOT rewrite older sections (`v0.10.0`, `v0.10.1`, `v0.10.2`) into Keep-a-Changelog format. Older sections don't block pre-flight; the wholesale rewrite is out of scope.
- Does NOT change product behavior.

## What happens after merge

Per the validation plan in arthur-debert/release#122: dispatch `release.yml` with `version: 0.10.3-rc.1` to do the first end-to-end run of `electron-app.yml@v1`'s macos signing + notarization path against a real consumer. The RC suffix makes it a `--prerelease` (visible but flagged), and the outcome answers the load-bearing open question: does electron-builder's native single-pass notarization actually succeed, or does it silent-hang as `skills/macos-signing-notarization/SKILL.md` warns?

## Test plan

- [x] Pre-commit ran the full build + 50 e2e tests locally; all green
- [ ] CI passes
- [ ] Copilot + Gemini review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)