### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## v0.10.3 (2026-05-21)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexed",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexed",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@lex-fmt/lex-buffer": "file:./packages/lex-buffer",
         "@lex/monaco-inline-injections": "file:./packages/monaco-inline-injections",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lexed",
   "productName": "LexEd",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "LexEd editor for Lex",
   "author": {
     "name": "Arthur Debert",

--- a/shared/lex-deps.json
+++ b/shared/lex-deps.json
@@ -5,7 +5,7 @@
       "repo": "lex-fmt/lex"
     },
     "tree-sitter": {
-      "version": "v0.10.4",
+      "version": "v0.11.0",
       "repo": "lex-fmt/tree-sitter-lex"
     }
   }


### PR DESCRIPTION
Cascade-triggered release. Upstream: tree-sitter-lex@v0.11.0.

Cut by the on-upstream-released handler (Layer 2 of lex-fmt/lex#640).
See https://github.com/lex-fmt/lexed/actions/runs/26208932977 for the handler run.