### PR TITLE
chore(changelog): populate [Unreleased] for canonical-release validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Adopted the canonical `bin/build` from the `electron-app` release
   stack (`arthur-debert/release#160`). The release workflow now invokes
-  `bin/build` instead of `npm run build` directly, matching the per-
-  stack convention across the rest of the ecosystem.
+  `bin/build` instead of `npm run build` directly, matching the
+  per-stack convention across the rest of the ecosystem.
 - Migrated `on-upstream-released.yml` to the canonical
   `cascade-handler@v1` reusable workflow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Adopted the canonical `bin/build` from the `electron-app` release
+  stack (`arthur-debert/release#160`). The release workflow now invokes
+  `bin/build` instead of `npm run build` directly, matching the per-
+  stack convention across the rest of the ecosystem.
+- Migrated `on-upstream-released.yml` to the canonical
+  `cascade-handler@v1` reusable workflow.
+
+### Removed
+
+- Removed the bespoke `dependabot-auto-merge.yml`; the canonical
+  Dependabot auto-merge policy is delivered via repo ruleset.
+
 ## [0.10.4] - 2026-05-21
 
 


### PR DESCRIPTION
## Summary

Three infrastructure changes have landed since v0.10.4 and were never lifted into the CHANGELOG's `[Unreleased]` section. Populating it now so the next dispatch through the canonical `electron-app.yml@v1` produces meaningful release notes — this is the consumer-side prep for the electron-app stack pilot release tracked at arthur-debert/release#167.

- Adopted canonical `bin/build` (arthur-debert/release#160)
- Migrated `on-upstream-released.yml` to `cascade-handler@v1`
- Removed bespoke `dependabot-auto-merge.yml`

No product-facing code changes.

## Test plan

- [ ] Pre-flight only; verified by the actual canonical-release dispatch (separate, user-triggered action).