### PR TITLE
fix: bash-3.2-safe smoke array + ASCII gen-theme output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `scripts/smoke.sh`: bash 3.2-safe expansion of `SMOKE_PREFIX[@]` so
+  the mac smoke step (system `/bin/bash` 3.2 under `set -u`) doesn't
+  error when the array is empty.
+- `scripts/gen-theme.py`: replaced the `✓` glyph with ASCII `OK` so
+  Windows runners' cp1252 stdout doesn't fail the `theme:check` step.
+
 ## [0.10.5] - 2026-05-22
 
 

--- a/scripts/gen-theme.py
+++ b/scripts/gen-theme.py
@@ -191,7 +191,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-        print(f"  ✓ {TARGET.relative_to(REPO_DIR)} matches generator")
+        print(f"  OK {TARGET.relative_to(REPO_DIR)} matches generator")
         return 0
 
     TARGET.write_text(expected, encoding="utf-8")

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -68,4 +68,8 @@ export E2E_SKIP_BUILD=1
 echo "smoke.sh: PLATFORM=${PLATFORM} ARCH=${ARCH} → ${PACKAGED_APP_PATH}"
 echo "smoke.sh: running Playwright packaged project"
 
-"${SMOKE_PREFIX[@]}" npx playwright test --project=packaged
+# `${SMOKE_PREFIX[@]+"${SMOKE_PREFIX[@]}"}`: bash 3.2-safe expansion
+# of a possibly-empty array under `set -u`. /bin/bash on the macOS
+# runner is 3.2; on 3.2, `"${arr[@]}"` errors with "unbound variable"
+# when arr is empty. The `+` form only expands when set.
+${SMOKE_PREFIX[@]+"${SMOKE_PREFIX[@]}"} npx playwright test --project=packaged


### PR DESCRIPTION
## Summary

Two consumer-side bugs surfaced by the v0.10.5 dispatch through canonical `electron-app.yml@v1` (arthur-debert/release#176). The canonical worked end-to-end on mac (build + submit/poll/staple notarize); platform-specific runtime quirks in our own scripts broke the post-build steps:

- **`scripts/smoke.sh:71`** — macOS GitHub runners use system `/bin/bash` (3.2). Under `set -u`, expanding an empty array with `"${arr[@]}"` errors with *"unbound variable"* (bash 4.4 fixed this). The mac and windows branches set `SMOKE_PREFIX=()`, so they hit it on first run. Fix: `${SMOKE_PREFIX[@]+"${SMOKE_PREFIX[@]}"}` — expand only if set.

- **`scripts/gen-theme.py:194`** — Windows Python's stdout defaults to cp1252, which can't encode U+2713 (`✓`). The `theme:check` prebuild step crashed before electron-builder could run. Fix: replace `✓` with ASCII `OK` (smaller diff than reconfiguring stdout to UTF-8).

Failure refs: build-mac (arm64), build-windows (x64) in [run 26313246432](https://github.com/lex-fmt/lexed/actions/runs/26313246432).

## Test plan

- [x] Local: `bash -c 'set -euo pipefail; SMOKE_PREFIX=(); ${SMOKE_PREFIX[@]+"${SMOKE_PREFIX[@]}"} echo ok'` runs clean
- [x] Local: `python3 scripts/gen-theme.py --check` prints `OK ... matches generator`
- [ ] Re-dispatch v0.10.6 once merged → mac + windows builds pass → release published

Once merged, follow up with `gh workflow run release.yml --field version=0.10.6 --repo lex-fmt/lexed` to validate the canonical end-to-end. v0.10.5 tag exists with no GH release (prepare succeeded, platform builds failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)