### PR TITLE
feat: add canonical bin/e2e shim (take-iii Queue A.2)

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canonical electron-app e2e runner. Same script local + CI.
+#
+# Delegates to the consumer's `npm run test:e2e` script (or pnpm/yarn
+# equivalent). The consumer's package.json owns what e2e actually
+# means: typically `playwright test tests/e2e` (often gated on a
+# pre-built binary via E2E_USE_BUILD / E2E_HIDE_WINDOW / similar env
+# vars). The electron-ci.yml@v1 workflow's `e2e: true` job runs this
+# script after the packaged build is available.
+#
+# Skip-with-notice if the consumer hasn't wired a `test:e2e` script —
+# repos still scaffolding e2e shouldn't fail the umbrella when the
+# tests don't exist yet.
+#
+# Usage:
+#   bin/e2e                          # default invocation
+#   bin/e2e --grep "some name"       # forward args to the test runner
+#
+# `"$@"` forwards extra args to the underlying script (npm passes them
+# verbatim after `--`; pnpm/yarn forward natively).
+#
+# Source of truth: arthur-debert/release templates/electron-app/bin/e2e.
+
+detect_pm() {
+    local root
+    root="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+    if [ -f pnpm-lock.yaml ] || [ -f "${root}/pnpm-lock.yaml" ]; then
+        echo "pnpm"
+    elif [ -f yarn.lock ] || [ -f "${root}/yarn.lock" ]; then
+        echo "yarn"
+    else
+        echo "npm"
+    fi
+}
+
+if [ ! -f package.json ]; then
+    echo "No package.json — skipping e2e."
+    exit 0
+fi
+
+if ! node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts['test:e2e'] ? 0 : 1)" 2>/dev/null; then
+    echo "No 'test:e2e' script in package.json — skipping e2e."
+    exit 0
+fi
+
+PM=$(detect_pm)
+echo "Running e2e tests via ${PM} run test:e2e..."
+case "${PM}" in
+    npm)        exec npm run --silent test:e2e -- "$@" ;;
+    pnpm|yarn)  exec "${PM}" test:e2e "$@" ;;
+esac

--- a/bin/e2e
+++ b/bin/e2e
@@ -3,36 +3,29 @@ set -euo pipefail
 
 # Canonical electron-app e2e runner. Same script local + CI.
 #
-# Delegates to the consumer's `npm run test:e2e` script (or pnpm/yarn
-# equivalent). The consumer's package.json owns what e2e actually
-# means: typically `playwright test tests/e2e` (often gated on a
-# pre-built binary via E2E_USE_BUILD / E2E_HIDE_WINDOW / similar env
-# vars). The electron-ci.yml@v1 workflow's `e2e: true` job runs this
-# script after the packaged build is available.
+# Delegates to the consumer's `<pm> run test:e2e` script. The
+# consumer's package.json owns what e2e actually means: typically
+# `playwright test tests/e2e` (often gated on a pre-built binary via
+# E2E_USE_BUILD / E2E_HIDE_WINDOW / similar env vars). The
+# electron-ci.yml@v1 workflow's `e2e: true` job runs this script
+# after the packaged build is available.
 #
-# Skip-with-notice if the consumer hasn't wired a `test:e2e` script —
-# repos still scaffolding e2e shouldn't fail the umbrella when the
-# tests don't exist yet.
-#
-# Usage:
-#   bin/e2e                          # default invocation
-#   bin/e2e --grep "some name"       # forward args to the test runner
-#
-# `"$@"` forwards extra args to the underlying script (npm passes them
-# verbatim after `--`; pnpm/yarn forward natively).
-#
-# Source of truth: arthur-debert/release templates/electron-app/bin/e2e.
+# Skip-with-notice if the consumer hasn't wired a `test:e2e` script.
 
+# CWD-first pm detection across all three lockfile types, falling
+# back to repo root only after exhausting CWD. This matters in
+# monorepos where a subdir-local lockfile of one type can coexist
+# with a root lockfile of another (e.g. an npm-managed subpackage
+# under a pnpm workspace).
 detect_pm() {
+    if [ -f pnpm-lock.yaml ]; then echo pnpm; return; fi
+    if [ -f yarn.lock ];      then echo yarn; return; fi
+    if [ -f package-lock.json ]; then echo npm; return; fi
     local root
     root="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
-    if [ -f pnpm-lock.yaml ] || [ -f "${root}/pnpm-lock.yaml" ]; then
-        echo "pnpm"
-    elif [ -f yarn.lock ] || [ -f "${root}/yarn.lock" ]; then
-        echo "yarn"
-    else
-        echo "npm"
-    fi
+    if [ -f "${root}/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+    if [ -f "${root}/yarn.lock" ];      then echo yarn; return; fi
+    echo npm
 }
 
 if [ ! -f package.json ]; then
@@ -40,7 +33,8 @@ if [ ! -f package.json ]; then
     exit 0
 fi
 
-if ! node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts['test:e2e'] ? 0 : 1)" 2>/dev/null; then
+# Optional chaining (Node >= 14) — cleaner than the && guard.
+if ! node -e "process.exit(require('./package.json').scripts?.['test:e2e'] ? 0 : 1)" 2>/dev/null; then
     echo "No 'test:e2e' script in package.json — skipping e2e."
     exit 0
 fi
@@ -49,5 +43,5 @@ PM=$(detect_pm)
 echo "Running e2e tests via ${PM} run test:e2e..."
 case "${PM}" in
     npm)        exec npm run --silent test:e2e -- "$@" ;;
-    pnpm|yarn)  exec "${PM}" test:e2e "$@" ;;
+    pnpm|yarn)  exec "${PM}" run test:e2e "$@" ;;
 esac


### PR DESCRIPTION
## Summary

Adds the canonical take-iii `bin/<verb>` shim(s) listed below so this repo passes the strict pilot-running criterion under `bin/done-check` (arthur-debert/release#178).

## What

- `bin/e2e` (electron-app) — delegates to `<pm> run test:e2e`

Content matches `templates/<stack>/bin/<verb>` in `arthur-debert/release` (sourced from arthur-debert/release#199 — landed/in-flight). Identical shim across every consumer of the same stack.

## Test plan

- [x] `bash -n` clean on the added file(s)
- [ ] CI green
- [ ] After merge: `done-check --repo <this-repo>` flips to *pilot-running*

Refs arthur-debert/release#107, arthur-debert/release#178, arthur-debert/release#199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)