### PR TITLE
chore: release v0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## v0.10.7 (2026-05-24)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexed",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexed",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "@lex-fmt/lex-buffer": "file:./packages/lex-buffer",
         "@lex/monaco-inline-injections": "file:./packages/monaco-inline-injections",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lexed",
   "productName": "LexEd",
   "private": true,
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "LexEd editor for Lex",
   "author": {
     "name": "Arthur Debert",


### PR DESCRIPTION
Cascade-triggered release. Upstream: tree-sitter-lex@v0.11.1-rc.1.

Cut by the cascade-handler reusable workflow at arthur-debert/release/.github/workflows/cascade-handler.yml.
See https://github.com/lex-fmt/lexed/actions/runs/26367253083 for the handler run.