### PR TITLE
fix(changelog): add missing migration fragment + markdownlint glob

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 CHANGELOG.md
 CHANGELOG/legacy.md
+CHANGELOG/unreleased-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Migrate changelog handling to the fragment-directory model
   (arthur-debert/release#201). Future entries go in
-  CHANGELOG/unreleased-<slug>.md fragments via `bin/changelog add`.
+  CHANGELOG/unreleased-`<slug>`.md fragments via `bin/changelog add`.
 
 
 ## v0.10.7 (2026-05-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+- Migrate changelog handling to the fragment-directory model
+  (arthur-debert/release#201). Future entries go in
+  CHANGELOG/unreleased-<slug>.md fragments via `bin/changelog add`.
+
 
 ## v0.10.7 (2026-05-24)
 

--- a/CHANGELOG/unreleased-migrate-to-fragment-dir.md
+++ b/CHANGELOG/unreleased-migrate-to-fragment-dir.md
@@ -1,0 +1,3 @@
+- Migrate changelog handling to the fragment-directory model
+  (arthur-debert/release#201). Future entries go in
+  CHANGELOG/unreleased-<slug>.md fragments via `bin/changelog add`.

--- a/CHANGELOG/unreleased-migrate-to-fragment-dir.md
+++ b/CHANGELOG/unreleased-migrate-to-fragment-dir.md
@@ -1,3 +1,3 @@
 - Migrate changelog handling to the fragment-directory model
   (arthur-debert/release#201). Future entries go in
-  CHANGELOG/unreleased-<slug>.md fragments via `bin/changelog add`.
+  CHANGELOG/unreleased-`<slug>`.md fragments via `bin/changelog add`.


### PR DESCRIPTION
## Summary

The original migration PR (#118) was missing `CHANGELOG/unreleased-migrate-to-fragment-dir.md` — the agent reported adding it but didn't. As a result, the first RC dispatch (v0.10.7-rc.1) failed in `prepare-release`'s extract step:

```
No CHANGELOG/unreleased-*.md fragments to extract in ./CHANGELOG
```

Add the fragment now + extend `.markdownlintignore` to cover `CHANGELOG/unreleased-*.md` (same rationale as the existing `CHANGELOG.md` and `CHANGELOG/legacy.md` entries — generated/snippet content, not standalone docs).

After merge, the v0.10.7-rc.1 dispatch can be retried.

Refs arthur-debert/release#201, arthur-debert/release#209