### PR TITLE
chore: lint cleanup for strict shell-quality gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-## Releasing
+# Releasing
 
 This repo participates in the lex release cascade. Cutting a release here is triggered automatically when lex or tree-sitter-lex releases (via the `on-upstream-released` handler workflow). lexed receives events from both upstreams; the handler re-checks all pins (`shared/lex-deps.json` — nested `.deps.<name>.{version,repo}` schema) via `should-release`.
 


### PR DESCRIPTION
Content-only pre-cleaning ahead of release/'s strict-gate tightening (arthur-debert/release#288). When the strict gate lands it (a) removes the `severity=warning` floor for shellcheck and (b) drops the `live-tests/**` / `test/**` / `tests/e2e/**` path excludes — so owned files in every path must already pass `shellcheck --severity=info` and strict markdownlint.

This PR scopes to the FUTURE strict gate, not the repo's current relaxed config.

## What this repo actually had

**Shell (owned, non-symlink):** `bin/check-lint`, `bin/lexed`, `bin/check-fmt`, `app-bin/build-quicklook.sh`. All four already pass `shellcheck --severity=info` with **zero findings** — no shell changes needed. (No `live-tests/`, no `.sh`/`.bash` under `tests/`; the e2e suite is TypeScript/Playwright, out of lint scope.)

**Markdown (owned, non-skill, non-vendor, non-generated):** `README.md`, `CLAUDE.md`, `tests/fixtures/sample.md`.

## Finding categories fixed

- **MD041** (first line must be a top-level heading): `CLAUDE.md` opened with `## Releasing` → promoted to `# Releasing`. Single-line, content-only change.

No `# shellcheck disable` directives were added (none needed).

## Scope notes

- `.release/` symlink targets, `.shellcheckrc`/`.markdownlint*`/`lefthook.yml` (symlinks), `vendor/`, `.claude/skills/`, `CHANGELOG.md` (generated — `<!-- generated - do not edit -->`) and `CHANGELOG/` were all left untouched per the managed-config / generated-artifact rules.

## Proof (local strict lint)

CI here still runs the relaxed config, so verification is local strict lint:

```
$ shellcheck --severity=info bin/check-lint bin/lexed bin/check-fmt app-bin/build-quicklook.sh
# (no output — 0 findings)

$ markdownlint --config strict.json README.md CLAUDE.md tests/fixtures/sample.md
# (no output — 0 findings)
```
where `strict.json` = `{"MD013":false,"line-length":false,"MD060":false,"table-column-style":false}` (MD056 stays on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)