### PR TITLE
ci: bump release reusable workflows to @v2

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/on-upstream-released.yml
+++ b/.github/workflows/on-upstream-released.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   cascade:
-    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v1
+    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v2
     with:
       git-author-name: lex-fmt release-bot
       git-author-email: release-bot@lex-fmt.local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/electron-app.yml@v1
+    uses: arthur-debert/release/.github/workflows/electron-app.yml@v2
     with:
       version: ${{ inputs.version }}
       app-name: LexEd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check:
-    uses: arthur-debert/release/.github/workflows/electron-ci.yml@v1
+    uses: arthur-debert/release/.github/workflows/electron-ci.yml@v2
     with:
       node-version: '22.18.0'
       shared-build-dir: shared


### PR DESCRIPTION
Moves onto release/'s v2 major line (v2.0.0 = strict lint gate). Reusable workflows unchanged v1→v2; behavior-neutral. Admin-merged without the review loop per maintainer direction.