### PR TITLE
fix(macos): ship only bin/lexed in extraResources, not whole bin/ (#142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,8 +136,8 @@
           "to": "lexd-lsp"
         },
         {
-          "from": "bin",
-          "to": "bin"
+          "from": "bin/lexed",
+          "to": "bin/lexed"
         }
       ],
       "extendInfo": {


### PR DESCRIPTION
## What

Narrows `build.mac.extraResources` from `{from: "bin", to: "bin"}` to `{from: "bin/lexed", to: "bin/lexed"}`.

## Why

The macOS release build (issue #142, run [26766373413](https://github.com/lex-fmt/lexed/actions/runs/26766373413)) failed in electron-builder packaging:

```
⨯ ENOENT: no such file or directory, stat '.../LexEd.app/Contents/Resources/bin/build'  failedTask=build
```

Copying the whole `bin/` dir into `Resources/bin/` broke after #130 turned `bin/build`, `bin/changelog`, etc. into symlinks → `../.release/bin/*`. Those land as **dangling symlinks** inside the `.app`, and electron-builder's post-copy `stat` throws ENOENT.

The app only needs `bin/lexed` at runtime (`electron/main.ts` → `path.join(process.resourcesPath, 'bin', 'lexed')`). `bin/lexed` is a real, self-contained script (verified: no references to sibling `bin/*` scripts). Shipping the rest was always over-broad.

> The issue was filed as a signing failure — but the QuickLook `.appex` signing **succeeded**; the failure is purely in resource copy.

## Scope

This fixes **only** the macOS `build-mac (arm64)` failure. The Windows `build-windows (x64)` failure in the same run is a **separate** root cause (`vite build` can't resolve `../resources/*` query imports — regressed with the canonical `fetch-deps` migration #125/#131) and is being investigated separately.

## Test plan

- [ ] `release / build-mac (arm64)` reaches notarization + produces the DMG
- [ ] CLI install (`lexed` command) still resolves the bundled `Resources/bin/lexed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)