### PR TITLE
chore(changelog): fragment for v0.10.7 re-cut (#142 build fixes)

### DIFF
--- a/CHANGELOG/unreleased-fix-platform-release-builds.md
+++ b/CHANGELOG/unreleased-fix-platform-release-builds.md
@@ -1,0 +1,1 @@
+Fix macOS and Windows release builds (#142). macOS: bundle only `bin/lexed` in app Resources instead of the whole `bin/` dir, which after the symlink migration shipped dangling links that aborted electron-builder. Windows: resource fetch (`fetch-deps`) CRLF bug fixed upstream so tree-sitter wasm + queries land correctly.


### PR DESCRIPTION
Adds a changelog fragment so `v0.10.7` can be re-cut.

The original `v0.10.7` release run failed in the platform build jobs (#142) but its `prepare` step had already rolled the changelog (`CHANGELOG/0.10.7.md`) and consumed the unreleased fragments. Re-dispatching the release now fails with *"No CHANGELOG/unreleased-*.md fragments found"*. This fragment documents the actual change in the re-cut:

- **macOS** — ship only `bin/lexed` in `extraResources` (PR #143), fixing the dangling-symlink `ENOENT` from electron-builder.
- **Windows** — resource fetch CRLF bug fixed upstream (`arthur-debert/release#409`), verified on a real Windows runner.

Merge this, then the `v0.10.7` release can be re-dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)