### PR TITLE
test(lib/files): cover file-type detection and action enablement

### DIFF
--- a/CHANGELOG/unreleased-files-actions-tests.md
+++ b/CHANGELOG/unreleased-files-actions-tests.md
@@ -1,1 +1,1 @@
-Add unit tests for lib/files file-type detection and file-action enablement
+- Add unit tests for lib/files file-type detection and file-action enablement (#153)

--- a/CHANGELOG/unreleased-files-actions-tests.md
+++ b/CHANGELOG/unreleased-files-actions-tests.md
@@ -1,0 +1,1 @@
+Add unit tests for lib/files file-type detection and file-action enablement

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getLanguageForFile,
+  isLexFile,
+  isMarkdownFile,
+  getFileActions,
+  type FileActionId,
+} from '@/lib/files'
+
+describe('getLanguageForFile', () => {
+  it('maps .lex and .lexd to the lex language', () => {
+    expect(getLanguageForFile('notes.lex')).toBe('lex')
+    expect(getLanguageForFile('notes.lexd')).toBe('lex')
+  })
+
+  it('maps markdown, html, and txt extensions', () => {
+    expect(getLanguageForFile('readme.md')).toBe('markdown')
+    expect(getLanguageForFile('page.html')).toBe('html')
+    expect(getLanguageForFile('page.htm')).toBe('html')
+    expect(getLanguageForFile('log.txt')).toBe('plaintext')
+  })
+
+  it('is case-insensitive about the extension', () => {
+    expect(getLanguageForFile('NOTES.LEX')).toBe('lex')
+    expect(getLanguageForFile('README.MD')).toBe('markdown')
+    expect(getLanguageForFile('PAGE.HTML')).toBe('html')
+  })
+
+  it('falls back to plaintext for unknown or absent extensions', () => {
+    expect(getLanguageForFile('archive.tar.gz')).toBe('plaintext')
+    expect(getLanguageForFile('Makefile')).toBe('plaintext')
+    expect(getLanguageForFile('')).toBe('plaintext')
+  })
+
+  it('uses only the final extension of a multi-dotted path', () => {
+    expect(getLanguageForFile('my.notes.backup.lex')).toBe('lex')
+    expect(getLanguageForFile('a.lex.txt')).toBe('plaintext')
+  })
+
+  it('respects the extension even on a full directory path', () => {
+    expect(getLanguageForFile('/home/me/docs/spec.lexd')).toBe('lex')
+  })
+})
+
+describe('isLexFile', () => {
+  it('recognizes .lex and .lexd regardless of case', () => {
+    expect(isLexFile('a.lex')).toBe(true)
+    expect(isLexFile('a.lexd')).toBe(true)
+    expect(isLexFile('A.LEX')).toBe(true)
+    expect(isLexFile('A.LexD')).toBe(true)
+  })
+
+  it('rejects non-lex files', () => {
+    expect(isLexFile('a.md')).toBe(false)
+    expect(isLexFile('a.txt')).toBe(false)
+    // .lexd is lex but a name merely containing "lex" mid-string is not
+    expect(isLexFile('lexicon.json')).toBe(false)
+  })
+
+  it('treats null/undefined/empty as not a lex file', () => {
+    expect(isLexFile(null)).toBe(false)
+    expect(isLexFile(undefined)).toBe(false)
+    expect(isLexFile('')).toBe(false)
+  })
+})
+
+describe('isMarkdownFile', () => {
+  it('recognizes .md and .markdown regardless of case', () => {
+    expect(isMarkdownFile('a.md')).toBe(true)
+    expect(isMarkdownFile('a.markdown')).toBe(true)
+    expect(isMarkdownFile('README.MD')).toBe(true)
+    expect(isMarkdownFile('NOTES.Markdown')).toBe(true)
+  })
+
+  it('rejects non-markdown files', () => {
+    expect(isMarkdownFile('a.lex')).toBe(false)
+    expect(isMarkdownFile('a.mdx')).toBe(false)
+    expect(isMarkdownFile('a.txt')).toBe(false)
+  })
+
+  it('treats null/undefined/empty as not a markdown file', () => {
+    expect(isMarkdownFile(null)).toBe(false)
+    expect(isMarkdownFile(undefined)).toBe(false)
+    expect(isMarkdownFile('')).toBe(false)
+  })
+})
+
+describe('getFileActions', () => {
+  const LEX_ONLY: FileActionId[] = [
+    'exportMarkdown',
+    'exportHtml',
+    'preview',
+    'format',
+    'shareWhatsApp',
+  ]
+  const HAS_FILE: FileActionId[] = ['copyPath', 'copyRelativePath', 'revealInFolder']
+
+  it('enables lex-only and has-file actions for a lex file, but not convertToLex', () => {
+    const actions = getFileActions('doc.lex')
+    for (const id of LEX_ONLY) {
+      expect(actions[id].enabled, `${id} should be enabled for lex`).toBe(true)
+    }
+    for (const id of HAS_FILE) {
+      expect(actions[id].enabled, `${id} should be enabled when a file exists`).toBe(true)
+    }
+    expect(actions.convertToLex.enabled).toBe(false)
+  })
+
+  it('enables convertToLex and has-file actions for a markdown file, but not lex-only actions', () => {
+    const actions = getFileActions('doc.md')
+    expect(actions.convertToLex.enabled).toBe(true)
+    for (const id of LEX_ONLY) {
+      expect(actions[id].enabled, `${id} should be disabled for markdown`).toBe(false)
+    }
+    for (const id of HAS_FILE) {
+      expect(actions[id].enabled, `${id} should be enabled when a file exists`).toBe(true)
+    }
+  })
+
+  it('enables only has-file actions for a plain non-lex/non-markdown file', () => {
+    const actions = getFileActions('notes.txt')
+    expect(actions.convertToLex.enabled).toBe(false)
+    for (const id of LEX_ONLY) {
+      expect(actions[id].enabled).toBe(false)
+    }
+    for (const id of HAS_FILE) {
+      expect(actions[id].enabled).toBe(true)
+    }
+  })
+
+  it('disables every action when there is no file path', () => {
+    for (const path of [null, undefined, '']) {
+      const actions = getFileActions(path)
+      for (const action of Object.values(actions)) {
+        expect(action.enabled, `${action.id} should be disabled for ${String(path)}`).toBe(false)
+      }
+    }
+  })
+
+  it('returns every action with its own id matching its key (no copy/paste drift)', () => {
+    const actions = getFileActions('doc.lex')
+    for (const [key, action] of Object.entries(actions)) {
+      expect(action.id).toBe(key)
+      expect(typeof action.label).toBe('string')
+      expect(action.label.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -30,6 +30,9 @@ describe('getLanguageForFile', () => {
     expect(getLanguageForFile('archive.tar.gz')).toBe('plaintext')
     expect(getLanguageForFile('Makefile')).toBe('plaintext')
     expect(getLanguageForFile('')).toBe('plaintext')
+    // a trailing dot or a lone dot has an empty final segment → plaintext
+    expect(getLanguageForFile('file.')).toBe('plaintext')
+    expect(getLanguageForFile('.')).toBe('plaintext')
   })
 
   it('uses only the final extension of a multi-dotted path', () => {
@@ -55,6 +58,8 @@ describe('isLexFile', () => {
     expect(isLexFile('a.txt')).toBe(false)
     // .lexd is lex but a name merely containing "lex" mid-string is not
     expect(isLexFile('lexicon.json')).toBe(false)
+    // a directory path that ends in the extension name + slash is not a lex file
+    expect(isLexFile('a.lex/')).toBe(false)
   })
 
   it('treats null/undefined/empty as not a lex file', () => {
@@ -76,6 +81,8 @@ describe('isMarkdownFile', () => {
     expect(isMarkdownFile('a.lex')).toBe(false)
     expect(isMarkdownFile('a.mdx')).toBe(false)
     expect(isMarkdownFile('a.txt')).toBe(false)
+    // a directory path that ends in the extension name + slash is not markdown
+    expect(isMarkdownFile('a.md/')).toBe(false)
   })
 
   it('treats null/undefined/empty as not a markdown file', () => {


### PR DESCRIPTION
## What

Adds a focused vitest unit suite for `src/lib/files.ts` — previously untested core logic that drives which file actions (export, preview, convert, etc.) are enabled in the toolbar and context menus.

## Tests added (17)

- `getLanguageForFile`: `.lex`/`.lexd`→lex, md/html/htm/txt mappings, case-insensitivity, multi-dot paths (only the final extension counts), no-extension/empty fallback to plaintext, full directory paths.
- `isLexFile` / `isMarkdownFile`: case-insensitive extension match, null/undefined/empty handling, and that a mere substring (`lexicon.json`) is not a match.
- `getFileActions`: the enablement invariant — lex-only actions vs markdown-only `convertToLex` vs has-file actions, every action disabled when there is no path, and that each action's `id` matches its key (guards copy/paste drift in the action table).

## Notes

Unit-only (vitest `test:unit`); no e2e touched. `release-core gate` and `release-core test-unit` both green locally (208 unit tests pass, up from 191).

🤖 Generated with [Claude Code](https://claude.com/claude-code)