### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/on-upstream-released.yml
+++ b/.github/workflows/on-upstream-released.yml
@@ -1,6 +1,6 @@
 # Layer 2 handler: react to an upstream's release.
 #
-# Thin caller of arthur-debert/release's canonical `cascade-handler@v1`.
+# Thin caller of arthur-debert/release's canonical `cascade-handler@v3`.
 # The reusable workflow runs the 5 `scripts/release/` primitives in order:
 #   should-release → get-current-version → (compute new) → update-release
 #   → commit + branch + admin-merge PR → trigger-release
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   cascade:
-    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v2
+    uses: arthur-debert/release/.github/workflows/cascade-handler.yml@v3
     with:
       git-author-name: lex-fmt release-bot
       git-author-email: release-bot@lex-fmt.local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/electron-app.yml@v2
+    uses: arthur-debert/release/.github/workflows/electron-app.yml@v3
     with:
       version: ${{ inputs.version }}
       app-name: LexEd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check:
-    uses: arthur-debert/release/.github/workflows/electron-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/electron-ci.yml@v3
     with:
       node-version: '22.18.0'
       shared-build-dir: shared

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+- ci: migrate release reusable-workflow callers from @v2 to @v3


### PR DESCRIPTION
Re-pins the arthur-debert/release reusable-workflow callers from `@v2` to `@v3` after release cut **v3.0.0**.

**Why v3 is a MAJOR:** mechanical only — it removed the unused `wasm-package` input (release#634). lexed never set that input, so this is a pure pin bump with no behavior change.

**Callers bumped @v2 → @v3:**
- `.github/workflows/test.yml` — electron-ci.yml
- `.github/workflows/release.yml` — electron-app.yml
- `.github/workflows/on-upstream-released.yml` — cascade-handler.yml (+ prose floating-ref mention)

**Left untouched:**
- `copilot-review.yml@v1` — stays at v1
- All `secrets:` blocks — cross-org (lex-fmt) consumer, secrets explicitly listed and untouched
- The managed tree is **not** in this PR — it arrives via the consumer's own wheel pull, not a fleet push

Changelog fragment added (`CHANGELOG/unreleased-release-v3.md`). YAML validated.

🤖 Generated with Claude Code