### PR TITLE
LNT01-WS04: adopt canonical prettier config + reformat

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,43 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "es5",
-  "printWidth": 100
-}
+# The canonical prettier config for the json/ts/svelte leg of `shipit lint`
+# (ADR-0037, the gate owns the config; LNT01-WS03 #516). shipit ships this ONE
+# body and injects it (`prettier --config <this>`) into every invocation, so no
+# ancestor/user `.prettierrc` is ever consulted. It resolves the fleet's only
+# genuine rule conflict — four TypeScript repos disagreed on `semi` /
+# `trailingComma` — to one set; WS04 (#517) unifies + reformats those repos to
+# it. YAML (not JSON) is the carrier so this documentation can live inline.
+singleQuote: true
+printWidth: 100
+tabWidth: 2
+semi: false
+trailingComma: none
+
+# The svelte + tailwindcss plugins are a CAPABILITY, not a rule, and are SCOPED to
+# `.svelte` via this `overrides` block rather than declared as a top-level
+# `plugins:` list. A top-level list is unconditional: prettier resolves every
+# plugin on load for EVERY invocation of this config, including the plain
+# json/TS leg, so on a tree that has not provisioned the plugins into
+# `node_modules` (a --depth-1 clone, shipit's own conda-forge lint env) prettier
+# would abort on load before ever parsing the JSON/TS file — which
+# `is_prettier_plugin_load_failure` (#498) then reads as an environment gap and
+# fails the leg OPEN (rc 0), silently passing a genuinely dirty JSON/TS file.
+# Scoping the plugins to an override keyed on `*.svelte` means prettier only
+# resolves them when it is actually asked to format a `.svelte` file — the
+# json/TS leg never touches them and cannot be masked by their absence
+# (verified: prettier 3.8.5 leaves an override's `plugins` unresolved for
+# non-matching files).
+#
+# Where the svelte leg's plugins COME FROM (LNT01-WS07 #520): they are npm
+# packages, NOT on conda-forge, so they cannot join the pixi lint-deps block the
+# way `prettier` itself does. They ride the consumer repo's OWN
+# `package.json` devDependencies + `npm ci` — which shipit Tree provisioning
+# already runs on any `package.json` (src/shipit/tree/create.py) — so prettier
+# (on PATH from conda-forge) resolves them from the repo's `./node_modules` when
+# it formats a `.svelte` file. Only the Svelte-bearing repos (they run their own
+# prettier via npm scripts) carry `.svelte` files AND those devDependencies;
+# shipit itself has neither, so its conda-forge lint env needs no plugin install.
+overrides:
+  - files: "*.svelte"
+    options:
+      plugins:
+        - prettier-plugin-svelte
+        - prettier-plugin-tailwindcss

--- a/electron/file-routing.test.ts
+++ b/electron/file-routing.test.ts
@@ -6,7 +6,7 @@ import {
   routeOpenFile,
   updateRecentRoots,
   type OpenWindowState,
-  type RecentRoot,
+  type RecentRoot
 } from './file-routing'
 
 describe('isCaseSensitiveFs', () => {
@@ -114,7 +114,7 @@ describe('findBestRoot', () => {
       [
         { root: '/project', score: 10 },
         { root: '/project', score: 100 },
-        { root: '/project', score: 5 },
+        { root: '/project', score: 5 }
       ],
       (c) => c.root,
       (c) => c.score,
@@ -143,7 +143,7 @@ describe('routeOpenFile', () => {
       filePath: '/docs/a.lex',
       openWindows: [],
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toEqual({ kind: 'newWindow', filePath: '/docs/a.lex' })
   })
@@ -151,13 +151,13 @@ describe('routeOpenFile', () => {
   it('picks an open window whose root contains the file', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/elsewhere' },
-      { windowId: 2, root: '/docs' },
+      { windowId: 2, root: '/docs' }
     ]
     const route = routeOpenFile({
       filePath: '/docs/a.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toEqual({ kind: 'existingWindow', windowId: 2, filePath: '/docs/a.lex' })
   })
@@ -165,13 +165,13 @@ describe('routeOpenFile', () => {
   it('prefers the longest matching open root', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/docs' },
-      { windowId: 2, root: '/docs/sub' },
+      { windowId: 2, root: '/docs/sub' }
     ]
     const route = routeOpenFile({
       filePath: '/docs/sub/a.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
   })
@@ -179,13 +179,13 @@ describe('routeOpenFile', () => {
   it('among equally-specific open roots, prefers the focused window', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/docs', lastFocusedAt: 10 },
-      { windowId: 2, root: '/docs', lastFocusedAt: 5, isFocused: true },
+      { windowId: 2, root: '/docs', lastFocusedAt: 5, isFocused: true }
     ]
     const route = routeOpenFile({
       filePath: '/docs/a.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
   })
@@ -194,13 +194,13 @@ describe('routeOpenFile', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/docs', lastFocusedAt: 10 },
       { windowId: 2, root: '/docs', lastFocusedAt: 50 },
-      { windowId: 3, root: '/docs', lastFocusedAt: 5 },
+      { windowId: 3, root: '/docs', lastFocusedAt: 5 }
     ]
     const route = routeOpenFile({
       filePath: '/docs/a.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
   })
@@ -209,31 +209,31 @@ describe('routeOpenFile', () => {
     const windows: OpenWindowState[] = [{ windowId: 1, root: '/unrelated' }]
     const recent: RecentRoot[] = [
       { path: '/projects/old', lastUsedAt: 1 },
-      { path: '/projects/notes', lastUsedAt: 2 },
+      { path: '/projects/notes', lastUsedAt: 2 }
     ]
     const route = routeOpenFile({
       filePath: '/projects/notes/a.lex',
       openWindows: windows,
       recentRoots: recent,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toEqual({
       kind: 'newWindowWithRoot',
       root: '/projects/notes',
-      filePath: '/projects/notes/a.lex',
+      filePath: '/projects/notes/a.lex'
     })
   })
 
   it('among equally-specific recent roots, picks the most recently used', () => {
     const recent: RecentRoot[] = [
       { path: '/projects/notes', lastUsedAt: 10 },
-      { path: '/projects/notes', lastUsedAt: 100 },
+      { path: '/projects/notes', lastUsedAt: 100 }
     ]
     const route = routeOpenFile({
       filePath: '/projects/notes/a.lex',
       openWindows: [],
       recentRoots: recent,
-      platform: 'linux',
+      platform: 'linux'
     })
     // newWindowWithRoot is the right kind since no windows are open
     expect(route.kind).toBe('newWindowWithRoot')
@@ -246,7 +246,7 @@ describe('routeOpenFile', () => {
       filePath: '/projects/notes/a.lex',
       openWindows: windows,
       recentRoots: recent,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
   })
@@ -254,13 +254,13 @@ describe('routeOpenFile', () => {
   it('falls back to focused open window when no root matches', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/projects/a', lastFocusedAt: 10 },
-      { windowId: 2, root: '/projects/b', lastFocusedAt: 50, isFocused: true },
+      { windowId: 2, root: '/projects/b', lastFocusedAt: 50, isFocused: true }
     ]
     const route = routeOpenFile({
       filePath: '/tmp/orphan.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
   })
@@ -268,13 +268,13 @@ describe('routeOpenFile', () => {
   it('falls back to most-recently-focused open window when no focus flag is set', () => {
     const windows: OpenWindowState[] = [
       { windowId: 1, root: '/projects/a', lastFocusedAt: 10 },
-      { windowId: 2, root: '/projects/b', lastFocusedAt: 50 },
+      { windowId: 2, root: '/projects/b', lastFocusedAt: 50 }
     ]
     const route = routeOpenFile({
       filePath: '/tmp/orphan.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 2 })
   })
@@ -285,7 +285,7 @@ describe('routeOpenFile', () => {
       filePath: '/tmp/orphan.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'linux',
+      platform: 'linux'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
   })
@@ -296,7 +296,7 @@ describe('routeOpenFile', () => {
       filePath: '/users/alice/docs/a.lex',
       openWindows: windows,
       recentRoots: empty,
-      platform: 'darwin',
+      platform: 'darwin'
     })
     expect(route).toMatchObject({ kind: 'existingWindow', windowId: 1 })
   })
@@ -317,7 +317,7 @@ describe('updateRecentRoots', () => {
   it('keeps list sorted by lastUsedAt descending', () => {
     const existing: RecentRoot[] = [
       { path: '/projects/a', lastUsedAt: 10 },
-      { path: '/projects/b', lastUsedAt: 30 },
+      { path: '/projects/b', lastUsedAt: 30 }
     ]
     const result = updateRecentRoots(existing, '/projects/c', 20, 20, 'linux')
     expect(result.map((r) => r.path)).toEqual(['/projects/b', '/projects/c', '/projects/a'])
@@ -326,7 +326,7 @@ describe('updateRecentRoots', () => {
   it('caps the list to `max` entries', () => {
     const existing: RecentRoot[] = Array.from({ length: 5 }, (_, i) => ({
       path: `/p${i}`,
-      lastUsedAt: i,
+      lastUsedAt: i
     }))
     const result = updateRecentRoots(existing, '/new', 100, 3, 'linux')
     expect(result).toHaveLength(3)

--- a/electron/lsp-manager.ts
+++ b/electron/lsp-manager.ts
@@ -19,7 +19,7 @@ function resolveLspBinary(binaryName: string): { path: string; source: string; w
     return {
       path: resolved,
       source: 'env',
-      warning: `LEX_LSP_PATH set but binary not found: ${resolved}`,
+      warning: `LEX_LSP_PATH set but binary not found: ${resolved}`
     }
   }
 
@@ -152,7 +152,7 @@ export class LspManager {
 
     this.lspProcess = spawn(lspPath, [], {
       env,
-      cwd: lspCwd,
+      cwd: lspCwd
     })
 
     this.lspProcess.stdout?.on('data', (data: Buffer) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,20 +17,20 @@ import {
   PaneRowLayout,
   EditorSettings,
   FormatterSettings,
-  FileTreeSettings,
+  FileTreeSettings
 } from './window-manager'
 import {
   routeOpenFile,
   updateRecentRoots,
   type OpenWindowState,
-  type RecentRoot,
+  type RecentRoot
 } from './file-routing'
 import {
   appendFilesToWindowPaneLayout,
   dedupePreservingOrder,
   setWindowFolder,
   setWindowPaneLayout,
-  upsertWindowState,
+  upsertWindowState
 } from './window-state'
 import { randomUUID } from 'crypto'
 
@@ -93,7 +93,7 @@ log.info('Logging initialised', {
   file: log.transports.file.getFile()?.path,
   fileLevel: fileLogLevel,
   consoleLevel: consoleLogLevel,
-  nodeEnv: process.env.NODE_ENV,
+  nodeEnv: process.env.NODE_ENV
 })
 
 // Optional: Catch all unhandled errors
@@ -170,8 +170,8 @@ const store = new Store<AppSettings>({
         y: { type: 'number' },
         width: { type: 'number' },
         height: { type: 'number' },
-        isMaximized: { type: 'boolean' },
-      },
+        isMaximized: { type: 'boolean' }
+      }
     },
     openWindows: {
       type: 'array',
@@ -187,9 +187,9 @@ const store = new Store<AppSettings>({
           lastFolder: { type: 'string' },
           paneLayout: { type: 'array' },
           paneRows: { type: 'array' },
-          activePaneId: { type: 'string' },
-        },
-      },
+          activePaneId: { type: 'string' }
+        }
+      }
     },
     recentRoots: {
       type: 'array',
@@ -197,18 +197,18 @@ const store = new Store<AppSettings>({
         type: 'object',
         properties: {
           path: { type: 'string' },
-          lastUsedAt: { type: 'number' },
-        },
-      },
+          lastUsedAt: { type: 'number' }
+        }
+      }
     },
     editor: {
       type: 'object',
       properties: {
         showRuler: { type: 'boolean', default: false },
         rulerWidth: { type: 'number', default: 100 },
-        vimMode: { type: 'boolean', default: false },
+        vimMode: { type: 'boolean', default: false }
       },
-      default: {},
+      default: {}
     },
     formatter: {
       type: 'object',
@@ -221,24 +221,24 @@ const store = new Store<AppSettings>({
         indentString: { type: 'string', default: '    ' },
         preserveTrailingBlanks: { type: 'boolean', default: false },
         normalizeVerbatimMarkers: { type: 'boolean', default: true },
-        formatOnSave: { type: 'boolean', default: false },
+        formatOnSave: { type: 'boolean', default: false }
       },
-      default: {},
+      default: {}
     },
     spellcheck: {
       type: 'object',
       properties: {
         enabled: { type: 'boolean', default: true },
-        language: { type: 'string', default: 'en_US' },
+        language: { type: 'string', default: 'en_US' }
       },
-      default: {},
+      default: {}
     },
     fileTree: {
       type: 'object',
       properties: {
-        showHiddenFiles: { type: 'boolean', default: false },
+        showHiddenFiles: { type: 'boolean', default: false }
       },
-      default: {},
+      default: {}
     },
     keybindings: {
       type: 'object',
@@ -250,14 +250,14 @@ const store = new Store<AppSettings>({
             properties: {
               mac: { type: ['string', 'null'] },
               windows: { type: ['string', 'null'] },
-              linux: { type: ['string', 'null'] },
-            },
-          },
-        },
+              linux: { type: ['string', 'null'] }
+            }
+          }
+        }
       },
-      default: {},
-    },
-  },
+      default: {}
+    }
+  }
 })
 
 // Initialize WindowManager after store is created
@@ -292,7 +292,7 @@ function collectOpenWindowStates(): OpenWindowState[] {
       windowId: win.id,
       root: state?.lastFolder ?? null,
       isFocused: focused?.id === win.id,
-      lastFocusedAt: windowManager.getLastFocusedAt(win.id),
+      lastFocusedAt: windowManager.getLastFocusedAt(win.id)
     }
   })
 }
@@ -386,7 +386,7 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
 let applicationMenu: Electron.Menu | null = null
 let currentMenuState: MenuState = {
   hasOpenFile: false,
-  isLexFile: false,
+  isLexFile: false
 }
 
 interface CliPaths {
@@ -528,7 +528,7 @@ async function openFilesViaRouter(filePaths: string[]): Promise<FileRouteDestina
         id: newStateId,
         width: DEFAULT_WINDOW_BOUNDS.width,
         height: DEFAULT_WINDOW_BOUNDS.height,
-        lastFolder: root,
+        lastFolder: root
       },
       { showSplash: true }
     )
@@ -545,7 +545,7 @@ async function openFilesViaRouter(filePaths: string[]): Promise<FileRouteDestina
       {
         id: newStateId,
         width: DEFAULT_WINDOW_BOUNDS.width,
-        height: DEFAULT_WINDOW_BOUNDS.height,
+        height: DEFAULT_WINDOW_BOUNDS.height
       },
       { showSplash: true }
     )
@@ -577,14 +577,14 @@ function seedNewWindowState(stateId: string, files: string[], root: string | nul
     {
       id: paneId,
       tabs,
-      activeTab: tabs[tabs.length - 1] ?? null,
-    },
+      activeTab: tabs[tabs.length - 1] ?? null
+    }
   ]
   const paneRows = [{ id: rowId, paneIds: [paneId] }]
   const patch: Partial<import('./window-manager').WindowState> = {
     paneLayout,
     paneRows,
-    activePaneId: paneId,
+    activePaneId: paneId
   }
   if (root) patch.lastFolder = root
   const openWindows = store.store.openWindows || []
@@ -592,7 +592,7 @@ function seedNewWindowState(stateId: string, files: string[], root: string | nul
     'openWindows',
     upsertWindowState(openWindows, stateId, patch, {
       width: DEFAULT_WINDOW_BOUNDS.width,
-      height: DEFAULT_WINDOW_BOUNDS.height,
+      height: DEFAULT_WINDOW_BOUNDS.height
     })
   )
 }
@@ -666,7 +666,7 @@ function openCliPaths(cliPaths: CliPaths) {
         id: newStateId,
         width: DEFAULT_WINDOW_BOUNDS.width,
         height: DEFAULT_WINDOW_BOUNDS.height,
-        ...(folder ? { lastFolder: folder } : {}),
+        ...(folder ? { lastFolder: folder } : {})
       },
       { showSplash: true }
     )
@@ -711,7 +711,7 @@ ipcMain.handle('file-new', async (event, defaultPath?: string) => {
   if (!win) return null
   const { canceled, filePath } = await dialog.showSaveDialog(win, {
     defaultPath: defaultPath || undefined,
-    filters: [{ name: 'Lex Files', extensions: ['lex'] }],
+    filters: [{ name: 'Lex Files', extensions: ['lex'] }]
   })
   if (canceled || !filePath) {
     return null
@@ -726,7 +726,7 @@ ipcMain.handle('file-open', async (event) => {
   if (!win) return null
   const { canceled, filePaths } = await dialog.showOpenDialog(win, {
     properties: ['openFile'],
-    filters: [{ name: 'Lex Files', extensions: ['lex'] }],
+    filters: [{ name: 'Lex Files', extensions: ['lex'] }]
   })
   if (canceled || filePaths.length === 0) {
     return null
@@ -746,7 +746,7 @@ ipcMain.handle(
     const { canceled, filePaths } = await dialog.showOpenDialog(win, {
       title: options.title,
       properties: ['openFile'],
-      filters: options.filters,
+      filters: options.filters
     })
     if (canceled || filePaths.length === 0) {
       return null
@@ -799,7 +799,7 @@ ipcMain.handle('file-read-dir', async (_, dirPath: string) => {
     return entries.map((entry) => ({
       name: entry.name,
       isDirectory: entry.isDirectory(),
-      path: path.join(dirPath, entry.name),
+      path: path.join(dirPath, entry.name)
     }))
   } catch (error) {
     console.error('Failed to read directory:', error)
@@ -859,7 +859,7 @@ ipcMain.handle('folder-open', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender)
   if (!win) return null
   const { canceled, filePaths } = await dialog.showOpenDialog(win, {
-    properties: ['openDirectory'],
+    properties: ['openDirectory']
   })
   if (canceled || filePaths.length === 0) {
     return null
@@ -940,7 +940,7 @@ ipcMain.handle('get-open-tabs', async (event) => {
     return {
       panes: [{ id: randomUUID(), tabs: [], activeTab: null }],
       activePaneId: null,
-      rows: [],
+      rows: []
     }
   }
 
@@ -951,8 +951,8 @@ ipcMain.handle('get-open-tabs', async (event) => {
           {
             id: winState.activePaneId || randomUUID(),
             tabs: [], // Don't restore tabs from global settings to avoid confusion? Or should we?
-            activeTab: null,
-          },
+            activeTab: null
+          }
         ]
 
   const panes: PaneLayoutSettings[] = []
@@ -974,7 +974,7 @@ ipcMain.handle('get-open-tabs', async (event) => {
       activeTab:
         pane.activeTab && filteredTabs.includes(pane.activeTab)
           ? pane.activeTab
-          : filteredTabs[0] || null,
+          : filteredTabs[0] || null
     })
   }
 
@@ -999,7 +999,7 @@ ipcMain.handle('get-open-tabs', async (event) => {
               id: row.id || randomUUID(),
               paneIds,
               size: typeof row.size === 'number' ? row.size : undefined,
-              paneSizes,
+              paneSizes
             }
           })
           .filter((row) => row.paneIds.length > 0)
@@ -1011,8 +1011,8 @@ ipcMain.handle('get-open-tabs', async (event) => {
         id: randomUUID(),
         paneIds: panes.map((p) => p.id),
         size: undefined,
-        paneSizes: {},
-      },
+        paneSizes: {}
+      }
     ]
   } else {
     const referenced = new Set(rows.flatMap((row) => row.paneIds))
@@ -1030,7 +1030,7 @@ ipcMain.handle('get-open-tabs', async (event) => {
   return {
     panes,
     activePaneId,
-    rows,
+    rows
   }
 })
 
@@ -1051,13 +1051,13 @@ ipcMain.handle(
     const normalizedPanes: PaneLayoutSettings[] = panes.map((pane) => ({
       id: pane.id || randomUUID(),
       tabs: pane.tabs || [],
-      activeTab: pane.activeTab ?? null,
+      activeTab: pane.activeTab ?? null
     }))
     const normalizedRows: PaneRowLayout[] = rows.map((row) => ({
       id: row.id || randomUUID(),
       paneIds: row.paneIds || [],
       size: row.size,
-      paneSizes: row.paneSizes,
+      paneSizes: row.paneSizes
     }))
 
     const openWindows = store.store.openWindows || []
@@ -1230,7 +1230,7 @@ ipcMain.on('get-native-theme-sync', (event) => {
 ipcMain.on('update-menu-state', (_event, state: MenuState) => {
   applyMenuState({
     hasOpenFile: !!state?.hasOpenFile,
-    isLexFile: !!state?.isLexFile,
+    isLexFile: !!state?.isLexFile
   })
 })
 
@@ -1299,7 +1299,7 @@ function createMenu() {
                 label: 'Settings...',
                 accelerator: 'CmdOrCtrl+,' as const,
                 click: (_: Electron.MenuItem, focusedWindow: BaseWindow | undefined) =>
-                  getTargetWindow(focusedWindow)?.webContents.send('menu-show-settings'),
+                  getTargetWindow(focusedWindow)?.webContents.send('menu-show-settings')
               },
               { type: 'separator' as const },
               { role: 'services' as const },
@@ -1308,9 +1308,9 @@ function createMenu() {
               { role: 'hideOthers' as const },
               { role: 'unhide' as const },
               { type: 'separator' as const },
-              { role: 'quit' as const },
-            ],
-          },
+              { role: 'quit' as const }
+            ]
+          }
         ]
       : []),
     {
@@ -1319,25 +1319,25 @@ function createMenu() {
         {
           label: 'New Window',
           accelerator: 'CmdOrCtrl+Shift+N',
-          click: () => windowManager.createWindow(),
+          click: () => windowManager.createWindow()
         },
         {
           label: 'New File',
           accelerator: 'CmdOrCtrl+N',
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-new-file'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-new-file')
         },
         {
           label: 'Open File...',
           accelerator: 'CmdOrCtrl+O',
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-open-file'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-open-file')
         },
         {
           label: 'Open Folder...',
           accelerator: 'CmdOrCtrl+Shift+O',
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-open-folder'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-open-folder')
         },
         { type: 'separator' },
         {
@@ -1345,8 +1345,7 @@ function createMenu() {
           accelerator: 'CmdOrCtrl+S',
           id: 'menu-save',
           enabled: false,
-          click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-save'),
+          click: (_, focusedWindow) => getTargetWindow(focusedWindow)?.webContents.send('menu-save')
         },
         { type: 'separator' },
         {
@@ -1357,27 +1356,27 @@ function createMenu() {
               id: 'menu-export-markdown',
               enabled: false,
               click: (_, focusedWindow) =>
-                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'markdown'),
+                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'markdown')
             },
             {
               label: 'Export to HTML',
               id: 'menu-export-html',
               enabled: false,
               click: (_, focusedWindow) =>
-                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'html'),
+                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'html')
             },
             {
               label: 'Export to PDF',
               id: 'menu-export-pdf',
               enabled: false,
               click: (_, focusedWindow) =>
-                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'pdf'),
-            },
-          ],
+                getTargetWindow(focusedWindow)?.webContents.send('menu-export', 'pdf')
+            }
+          ]
         },
         { type: 'separator' },
-        isMac ? { role: 'close' } : { role: 'quit' },
-      ],
+        isMac ? { role: 'close' } : { role: 'quit' }
+      ]
     },
     {
       label: 'Edit',
@@ -1395,8 +1394,7 @@ function createMenu() {
           accelerator: 'CmdOrCtrl+F',
           id: 'menu-find',
           enabled: false,
-          click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-find'),
+          click: (_, focusedWindow) => getTargetWindow(focusedWindow)?.webContents.send('menu-find')
         },
         {
           label: 'Replace',
@@ -1404,7 +1402,7 @@ function createMenu() {
           id: 'menu-replace',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-replace'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-replace')
         },
         { type: 'separator' },
         {
@@ -1413,7 +1411,7 @@ function createMenu() {
           id: 'menu-format',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-format'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-format')
         },
         {
           label: 'Insert Asset',
@@ -1421,7 +1419,7 @@ function createMenu() {
           id: 'menu-insert-asset',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-insert-asset'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-insert-asset')
         },
         {
           label: 'Insert Verbatim',
@@ -1429,7 +1427,7 @@ function createMenu() {
           id: 'menu-insert-verbatim',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-insert-verbatim'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-insert-verbatim')
         },
         { type: 'separator' },
         {
@@ -1437,7 +1435,7 @@ function createMenu() {
           id: 'menu-reorder-footnotes',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-reorder-footnotes'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-reorder-footnotes')
         },
         { type: 'separator' },
         {
@@ -1446,7 +1444,7 @@ function createMenu() {
           id: 'menu-resolve-annotation',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-resolve-annotation'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-resolve-annotation')
         },
         {
           label: 'Next Annotation',
@@ -1454,7 +1452,7 @@ function createMenu() {
           id: 'menu-next-annotation',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-next-annotation'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-next-annotation')
         },
         {
           label: 'Previous Annotation',
@@ -1462,7 +1460,7 @@ function createMenu() {
           id: 'menu-prev-annotation',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-prev-annotation'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-prev-annotation')
         },
         // Settings in Edit menu for non-macOS platforms
         ...(!isMac
@@ -1472,11 +1470,11 @@ function createMenu() {
                 label: 'Settings',
                 accelerator: 'CmdOrCtrl+,' as const,
                 click: (_: Electron.MenuItem, focusedWindow: BaseWindow | undefined) =>
-                  getTargetWindow(focusedWindow)?.webContents.send('menu-show-settings'),
-              },
+                  getTargetWindow(focusedWindow)?.webContents.send('menu-show-settings')
+              }
             ]
-          : []),
-      ],
+          : [])
+      ]
     },
     {
       label: 'View',
@@ -1487,27 +1485,27 @@ function createMenu() {
           id: 'menu-preview',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-preview'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-preview')
         },
         {
           label: 'Toggle Annotations',
           id: 'menu-toggle-annotations',
           enabled: false,
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-toggle-annotations'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-toggle-annotations')
         },
         {
           label: 'Toggle Hidden Files',
           id: 'menu-toggle-hidden-files',
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-toggle-hidden-files'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-toggle-hidden-files')
         },
         { type: 'separator' },
         {
           label: 'Show Keyboard Shortcuts',
           accelerator: 'CmdOrCtrl+Shift+/',
           click: (_, focusedWindow) =>
-            getTargetWindow(focusedWindow)?.webContents.send('menu-show-shortcuts'),
+            getTargetWindow(focusedWindow)?.webContents.send('menu-show-shortcuts')
         },
         { type: 'separator' },
         { role: 'reload', accelerator: 'CmdOrCtrl+Alt+R' },
@@ -1518,8 +1516,8 @@ function createMenu() {
         { role: 'zoomIn' },
         { role: 'zoomOut' },
         { type: 'separator' },
-        { role: 'togglefullscreen' },
-      ],
+        { role: 'togglefullscreen' }
+      ]
     },
     // Shell menu (macOS only) - CLI installation
     ...(isMac
@@ -1543,7 +1541,7 @@ function createMenu() {
                       result.message
                     )
                   }
-                },
+                }
               },
               {
                 id: 'menu-uninstall-cli',
@@ -1561,10 +1559,10 @@ function createMenu() {
                       result.message
                     )
                   }
-                },
-              },
-            ],
-          },
+                }
+              }
+            ]
+          }
         ]
       : []),
     {
@@ -1574,9 +1572,9 @@ function createMenu() {
         { role: 'zoom' },
         ...(isMac
           ? [{ type: 'separator' as const }, { role: 'front' as const }]
-          : [{ role: 'close' as const }]),
-      ],
-    },
+          : [{ role: 'close' as const }])
+      ]
+    }
   ]
 
   applicationMenu = Menu.buildFromTemplate(template)
@@ -1657,7 +1655,7 @@ async function installCliCommand(): Promise<{ success: boolean; message: string 
     await execAsync(`osascript -e '${script}'`)
     return {
       success: true,
-      message: `Successfully installed 'lexed' command.\n\nYou can now open files with:\n  lexed /path/to/file.lex`,
+      message: `Successfully installed 'lexed' command.\n\nYou can now open files with:\n  lexed /path/to/file.lex`
     }
   } catch (error) {
     const err = error as Error & { code?: number }
@@ -1759,7 +1757,7 @@ if (!gotTheLock) {
       applicationName: 'LexEd',
       applicationVersion: app.getVersion(),
       copyright: 'Copyright © 2024 Lex',
-      credits: 'Developed by the Lex Team',
+      credits: 'Developed by the Lex Team'
     })
     createMenu()
 
@@ -1825,7 +1823,7 @@ if (!gotTheLock) {
         paneLayout: settings.paneLayout,
         paneRows: settings.paneRows,
         activePaneId: settings.activePaneId,
-        lastFolder: settings.lastFolder,
+        lastFolder: settings.lastFolder
       }
 
       store.set('openWindows', [legacyState])
@@ -1853,7 +1851,7 @@ if (!gotTheLock) {
           id: newStateId,
           width: DEFAULT_WINDOW_BOUNDS.width,
           height: DEFAULT_WINDOW_BOUNDS.height,
-          ...(cliPaths.folder ? { lastFolder: cliPaths.folder } : {}),
+          ...(cliPaths.folder ? { lastFolder: cliPaths.folder } : {})
         },
         { showSplash: true }
       )
@@ -1869,7 +1867,7 @@ if (!gotTheLock) {
           id: newStateId,
           width: DEFAULT_WINDOW_BOUNDS.width,
           height: DEFAULT_WINDOW_BOUNDS.height,
-          lastFolder: projectPath,
+          lastFolder: projectPath
         },
         { showSplash: true }
       )

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -211,5 +211,5 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
     ) => callback(type, message)
     ipcRenderer.on('show-toast', handler)
     return () => ipcRenderer.removeListener('show-toast', handler)
-  },
+  }
 })

--- a/electron/window-manager.ts
+++ b/electron/window-manager.ts
@@ -106,7 +106,7 @@ export interface AppSettings {
 
 const DEFAULT_WINDOW_STATE = {
   width: 1200,
-  height: 800,
+  height: 800
 }
 
 // Cap the number of windows we restore on launch. Entries accumulate in the
@@ -162,8 +162,8 @@ export class WindowManager {
       show: false,
       webPreferences: {
         nodeIntegration: false,
-        contextIsolation: true,
-      },
+        contextIsolation: true
+      }
     })
 
     // Read logo and embed as base64 to avoid file:// URL issues
@@ -276,8 +276,8 @@ export class WindowManager {
         backgroundColor: bgColor,
         webPreferences: {
           preload: path.join(__dirname, 'preload.mjs'),
-          backgroundThrottling: false,
-        },
+          backgroundThrottling: false
+        }
       })
 
       if (restoreState?.isMaximized) {
@@ -361,7 +361,7 @@ export class WindowManager {
       y: bounds.y,
       width: isMaximized ? DEFAULT_WINDOW_STATE.width : bounds.width,
       height: isMaximized ? DEFAULT_WINDOW_STATE.height : bounds.height,
-      isMaximized,
+      isMaximized
     })
 
     this.store.set('openWindows', updated)

--- a/electron/window-state.test.ts
+++ b/electron/window-state.test.ts
@@ -5,7 +5,7 @@ import {
   upsertWindowState,
   mergeBounds,
   setWindowFolder,
-  setWindowPaneLayout,
+  setWindowPaneLayout
 } from './window-state'
 import type { WindowState } from './window-manager'
 
@@ -31,8 +31,8 @@ describe('upsertWindowState', () => {
         width: 800,
         height: 600,
         isMaximized: false,
-        lastFolder: '/old',
-      },
+        lastFolder: '/old'
+      }
     ]
     const result = upsertWindowState(
       existing,
@@ -48,8 +48,8 @@ describe('upsertWindowState', () => {
         width: 800,
         height: 600,
         isMaximized: false,
-        lastFolder: '/new',
-      },
+        lastFolder: '/new'
+      }
     ])
   })
 
@@ -70,15 +70,15 @@ describe('mergeBounds', () => {
         width: 800,
         height: 600,
         isMaximized: false,
-        lastFolder: '/docs',
-      },
+        lastFolder: '/docs'
+      }
     ]
     const result = mergeBounds(existing, 'abc', {
       x: 200,
       y: 100,
       width: 1400,
       height: 900,
-      isMaximized: false,
+      isMaximized: false
     })
     expect(result[0]).toEqual({
       id: 'abc',
@@ -87,7 +87,7 @@ describe('mergeBounds', () => {
       width: 1400,
       height: 900,
       isMaximized: false,
-      lastFolder: '/docs',
+      lastFolder: '/docs'
     })
   })
 
@@ -100,15 +100,15 @@ describe('mergeBounds', () => {
         width: 800,
         height: 600,
         isMaximized: false,
-        lastFolder: '/docs',
-      },
+        lastFolder: '/docs'
+      }
     ]
     const result = mergeBounds(existing, 'abc', {
       x: 200,
       y: 100,
       width: 1400,
       height: 900,
-      isMaximized: true,
+      isMaximized: true
     })
     expect(result[0].x).toBeUndefined()
     expect(result[0].y).toBeUndefined()
@@ -122,7 +122,7 @@ describe('mergeBounds', () => {
       y: 100,
       width: 1400,
       height: 900,
-      isMaximized: false,
+      isMaximized: false
     })
     expect(result).toEqual([
       {
@@ -131,8 +131,8 @@ describe('mergeBounds', () => {
         y: 100,
         width: 1400,
         height: 900,
-        isMaximized: false,
-      },
+        isMaximized: false
+      }
     ])
   })
 })
@@ -153,7 +153,7 @@ describe('setWindowFolder', () => {
   it('does not touch unrelated entries', () => {
     const existing: WindowState[] = [
       { id: 'abc', width: 800, height: 600, lastFolder: '/a' },
-      { id: 'xyz', width: 1200, height: 800, lastFolder: '/b' },
+      { id: 'xyz', width: 1200, height: 800, lastFolder: '/b' }
     ]
     const result = setWindowFolder(existing, 'abc', '/new', defaultBounds)
     expect(result[1]).toEqual(existing[1])
@@ -184,8 +184,8 @@ describe('setWindowPaneLayout', () => {
         lastFolder: '/docs',
         paneLayout: [{ id: 'old', tabs: [] }],
         paneRows: [],
-        activePaneId: 'old',
-      },
+        activePaneId: 'old'
+      }
     ]
     const result = setWindowPaneLayout(
       existing,
@@ -206,7 +206,7 @@ describe('appendFilesToWindowPaneLayout', () => {
     id: 'abc',
     width: 1200,
     height: 800,
-    lastFolder: '/docs',
+    lastFolder: '/docs'
   })
 
   it('returns the state unchanged when given no files', () => {
@@ -229,7 +229,7 @@ describe('appendFilesToWindowPaneLayout', () => {
     const result = appendFilesToWindowPaneLayout(baseState(), [
       '/docs/a.lex',
       '/docs/a.lex',
-      '/docs/b.lex',
+      '/docs/b.lex'
     ])
     expect(result.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
     expect(result.paneLayout?.[0].activeTab).toBe('/docs/b.lex')
@@ -240,10 +240,10 @@ describe('appendFilesToWindowPaneLayout', () => {
       ...baseState(),
       paneLayout: [
         { id: 'p1', tabs: ['/docs/old.lex'], activeTab: '/docs/old.lex' },
-        { id: 'p2', tabs: [], activeTab: null },
+        { id: 'p2', tabs: [], activeTab: null }
       ],
       paneRows: [{ id: 'r1', paneIds: ['p1', 'p2'] }],
-      activePaneId: 'p1',
+      activePaneId: 'p1'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/docs/new.lex'])
     expect(result.paneLayout?.[0].tabs).toEqual(['/docs/old.lex', '/docs/new.lex'])
@@ -257,7 +257,7 @@ describe('appendFilesToWindowPaneLayout', () => {
       ...baseState(),
       paneLayout: [{ id: 'p1', tabs: ['/docs/old.lex'], activeTab: '/docs/old.lex' }],
       paneRows: [{ id: 'r1', paneIds: ['p1'] }],
-      activePaneId: 'gone',
+      activePaneId: 'gone'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/docs/new.lex'])
     expect(result.paneLayout?.[0].tabs).toEqual(['/docs/old.lex', '/docs/new.lex'])
@@ -269,7 +269,7 @@ describe('appendFilesToWindowPaneLayout', () => {
       ...baseState(),
       paneLayout: [{ id: 'p1', tabs: ['/docs/a.lex', '/docs/b.lex'], activeTab: '/docs/a.lex' }],
       paneRows: [{ id: 'r1', paneIds: ['p1'] }],
-      activePaneId: 'p1',
+      activePaneId: 'p1'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/docs/b.lex'])
     expect(result.paneLayout?.[0].tabs).toEqual(['/docs/a.lex', '/docs/b.lex'])
@@ -290,7 +290,7 @@ describe('appendFilesToWindowPaneLayout', () => {
       ...baseState(),
       paneLayout: [{ id: 'p1', tabs: [], activeTab: null }],
       paneRows: [],
-      activePaneId: 'p1',
+      activePaneId: 'p1'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/docs/a.lex'])
     expect(result.paneRows).toHaveLength(1)
@@ -302,7 +302,7 @@ describe('appendFilesToWindowPaneLayout', () => {
       ...baseState(),
       paneLayout: [{ id: 'p1', tabs: [], activeTab: null }],
       paneRows: [{ id: 'r1', paneIds: ['p1'] }],
-      activePaneId: 'p1',
+      activePaneId: 'p1'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/docs/a.lex'])
     expect(result.paneRows).toHaveLength(1)
@@ -317,7 +317,7 @@ describe('appendFilesToWindowPaneLayout', () => {
       width: 1024,
       height: 768,
       isMaximized: true,
-      lastFolder: '/projects/x',
+      lastFolder: '/projects/x'
     }
     const result = appendFilesToWindowPaneLayout(state, ['/projects/x/a.lex'])
     expect(result.x).toBe(100)

--- a/electron/window-state.ts
+++ b/electron/window-state.ts
@@ -56,14 +56,14 @@ export function mergeBounds(
       y: bounds.isMaximized ? undefined : bounds.y,
       width: bounds.width,
       height: bounds.height,
-      isMaximized: bounds.isMaximized,
+      isMaximized: bounds.isMaximized
     },
     {
       x: bounds.x,
       y: bounds.y,
       width: bounds.width,
       height: bounds.height,
-      isMaximized: bounds.isMaximized,
+      isMaximized: bounds.isMaximized
     }
   )
 }
@@ -81,7 +81,7 @@ export function setWindowFolder(
     {
       width: defaultBounds.width,
       height: defaultBounds.height,
-      lastFolder: folderPath,
+      lastFolder: folderPath
     }
   )
 }
@@ -103,7 +103,7 @@ export function setWindowPaneLayout(
       height: defaultBounds.height,
       paneLayout,
       paneRows,
-      activePaneId,
+      activePaneId
     }
   )
 }
@@ -134,11 +134,11 @@ export function appendFilesToWindowPaneLayout(state: WindowState, files: string[
         {
           id: paneId,
           tabs: dedupePreservingOrder(files),
-          activeTab: files[files.length - 1] ?? null,
-        },
+          activeTab: files[files.length - 1] ?? null
+        }
       ],
       paneRows: [{ id: rowId, paneIds: [paneId] }],
-      activePaneId: paneId,
+      activePaneId: paneId
     }
   }
 
@@ -169,7 +169,7 @@ export function appendFilesToWindowPaneLayout(state: WindowState, files: string[
     ...state,
     paneLayout: newPanes,
     paneRows: newRows,
-    activePaneId: targetPaneId,
+    activePaneId: targetPaneId
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
   insertAsset,
   insertVerbatim,
   resolveAnnotation,
-  toggleAnnotations,
+  toggleAnnotations
 } from './features/editing'
 import { nextAnnotation, previousAnnotation } from './features/navigation'
 import { exportContent, importContent, convertToHtml } from './features/interop'
@@ -47,7 +47,7 @@ interface LspErrorInfo {
 const createTabFromPath = (path: string): Tab => ({
   id: path,
   path,
-  name: path.split('/').pop() || path,
+  name: path.split('/').pop() || path
 })
 
 function AppContent() {
@@ -58,13 +58,13 @@ function AppContent() {
     setPaneRows,
     setActivePaneId,
     resolvedActivePane,
-    resolvedActivePaneId,
+    resolvedActivePaneId
   } = usePersistedPaneLayout(createTabFromPath)
   const { settings, updateFileTreeSettings } = useSettings()
   const { rootPath, setRootPath } = useRootFolder()
   const [exportStatus, setExportStatus] = useState<ExportStatus>({
     isExporting: false,
-    format: null,
+    format: null
   })
   const paneHandles = useRef(new Map<string, EditorPaneHandle | null>())
   const panesRef = useRef(panes)
@@ -74,7 +74,7 @@ function AppContent() {
   if (!keybindingManagerRef.current) {
     keybindingManagerRef.current = new KeybindingManager(KEYBINDING_DEFINITIONS, {
       platform,
-      overrides: settings.keybindings,
+      overrides: settings.keybindings
     })
   }
 
@@ -151,19 +151,19 @@ function AppContent() {
               status.message ??
               `Lex LSP binary was not found${status.path ? ` at ${status.path}` : ''}.`,
             suggestion:
-              'Run "bash scripts/fetch-deps.sh" to download lexd-lsp, or use "npm run dev" which fetches it automatically.',
+              'Run "bash scripts/fetch-deps.sh" to download lexd-lsp, or use "npm run dev" which fetches it automatically.'
           })
         } else if (status.status === 'error') {
           setLspError({
             title: 'Lex Language Server Error',
             message: status.message ?? 'Unable to launch the Lex language server.',
-            suggestion: 'Check the terminal output for more information.',
+            suggestion: 'Check the terminal output for more information.'
           })
         } else if (status.status === 'stopped') {
           setLspError({
             title: 'Lex Language Server Stopped',
             message: 'The language server exited unexpectedly.',
-            suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.',
+            suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.'
           })
         }
       }) ?? (() => {})
@@ -174,7 +174,7 @@ function AppContent() {
       setLspError({
         title: 'Lex Language Server Unavailable',
         message: detail?.message ?? 'The language server is not responding.',
-        suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.',
+        suggestion: 'Restart LexEd or rebuild lexd-lsp to continue.'
       })
     }
 
@@ -243,13 +243,13 @@ function AppContent() {
     handleTabClose,
     handleTabDrop,
     handlePaneFileLoaded,
-    handlePaneCursorChange,
+    handlePaneCursorChange
   } = usePaneManager({
     activePaneId: activePaneIdValue,
     setActivePaneId,
     setPanes,
     setPaneRows,
-    createTabFromPath,
+    createTabFromPath
   })
 
   useLexTestBridge({
@@ -258,7 +258,7 @@ function AppContent() {
     panesRef,
     panes,
     openFileInPane,
-    setRootPath,
+    setRootPath
   })
 
   const handleNewFile = useCallback(async () => {
@@ -360,8 +360,8 @@ function AppContent() {
       toast.success(`Converted to ${fileName}`, {
         action: {
           label: 'Show',
-          onClick: () => window.ipcRenderer.showItemInFolder(outputPath),
-        },
+          onClick: () => window.ipcRenderer.showItemInFolder(outputPath)
+        }
       })
       openFileInPane(activePaneIdValue, outputPath)
     } catch (error) {
@@ -413,8 +413,8 @@ function AppContent() {
         toast.success(`Exported to ${fileName}`, {
           action: {
             label: 'Show',
-            onClick: () => window.ipcRenderer.showItemInFolder(outputPath),
-          },
+            onClick: () => window.ipcRenderer.showItemInFolder(outputPath)
+          }
         })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Export failed'
@@ -457,7 +457,7 @@ function AppContent() {
         previewTab,
         setPanes,
         setPaneRows,
-        setActivePaneId,
+        setActivePaneId
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Preview failed'
@@ -470,7 +470,7 @@ function AppContent() {
     setActivePaneId,
     setPaneRows,
     setPanes,
-    ensureLspAvailable,
+    ensureLspAvailable
   ])
 
   const handleFileSelect = useCallback(
@@ -491,7 +491,7 @@ function AppContent() {
     }
     const path = (await window.ipcRenderer.invoke('file-pick', {
       title: 'Select Asset',
-      filters: [{ name: 'All Files', extensions: ['*'] }],
+      filters: [{ name: 'All Files', extensions: ['*'] }]
     })) as string | null
     console.log('handleInsertAsset: path selected', path)
     if (path) {
@@ -504,7 +504,7 @@ function AppContent() {
     if (!activeEditor) return
     const path = (await window.ipcRenderer.invoke('file-pick', {
       title: 'Select File for Verbatim Block',
-      filters: [{ name: 'All Files', extensions: ['*'] }],
+      filters: [{ name: 'All Files', extensions: ['*'] }]
     })) as string | null
     if (path) {
       await insertVerbatim(activeEditor, path)
@@ -783,7 +783,7 @@ function AppContent() {
       handleSplitVertical,
       selectRelativeTab,
       setCommandPaletteOpen,
-      setShortcutsOpen,
+      setShortcutsOpen
     ]
   )
 
@@ -797,7 +797,7 @@ function AppContent() {
         ctrlKey: event.ctrlKey,
         altKey: event.altKey,
         shiftKey: event.shiftKey,
-        targetTagName: (event.target as HTMLElement | null)?.tagName,
+        targetTagName: (event.target as HTMLElement | null)?.tagName
       })
       if (!match) {
         return
@@ -835,7 +835,7 @@ function AppContent() {
     onToggleHiddenFiles: handleToggleHiddenFiles,
     onReorderFootnotes: handleReorderFootnotes,
     onOpenFilePath: handleOpenFilePath,
-    onShowShortcuts: () => setShortcutsOpen(true),
+    onShowShortcuts: () => setShortcutsOpen(true)
   })
 
   // File context menu handlers - these operate on a file path directly (e.g., from right-click menu)
@@ -894,7 +894,7 @@ function AppContent() {
             previewTab,
             setPanes,
             setPaneRows,
-            setActivePaneId,
+            setActivePaneId
           })
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Preview failed'
@@ -956,7 +956,7 @@ function AppContent() {
         }
       },
       onCopyPath: handleCopyPath,
-      onCopyRelativePath: handleCopyRelativePath,
+      onCopyRelativePath: handleCopyRelativePath
     }),
     [
       activePaneIdValue,
@@ -967,7 +967,7 @@ function AppContent() {
       panes,
       setActivePaneId,
       setPaneRows,
-      setPanes,
+      setPanes
     ]
   )
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -11,7 +11,7 @@ export class MonacoEditorAdapter implements EditorAdapter {
     const op = {
       range: selection,
       text: text,
-      forceMoveMarkers: true,
+      forceMoveMarkers: true
     }
     this.editor.executeEdits('lex-adapter', [op])
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ export async function insertAssetReference(editor: monaco.editor.IStandaloneCode
   // Request file selection from main process
   const filePath = await window.ipcRenderer.invoke<string | null>('dialog-show-open-dialog', {
     properties: ['openFile'],
-    title: 'Select asset to insert',
+    title: 'Select asset to insert'
   })
 
   if (!filePath) return
@@ -22,7 +22,7 @@ export async function insertAssetReference(editor: monaco.editor.IStandaloneCode
   const relativePath = await window.ipcRenderer.invoke<string>('path-relative', docPath, filePath)
 
   await commands.InsertAssetCommand.execute(adapter, {
-    path: relativePath,
+    path: relativePath
   })
 }
 
@@ -31,7 +31,7 @@ export async function insertVerbatimBlock(editor: monaco.editor.IStandaloneCodeE
 
   const filePath = await window.ipcRenderer.invoke<string | null>('dialog-show-open-dialog', {
     properties: ['openFile'],
-    title: 'Select file to embed as verbatim block',
+    title: 'Select file to embed as verbatim block'
   })
 
   if (!filePath) return
@@ -50,6 +50,6 @@ export async function insertVerbatimBlock(editor: monaco.editor.IStandaloneCodeE
 
   await commands.InsertVerbatimCommand.execute(adapter, {
     content: content.trim(),
-    language,
+    language
   })
 }

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   useCallback,
   useEffect,
-  useMemo,
+  useMemo
 } from 'react'
 import {
   Editor,
@@ -13,11 +13,11 @@ import {
   getOrCreateModel,
   disposeModel,
   applyTheme,
-  type ThemeMode,
+  type ThemeMode
 } from '@lex-fmt/lex-buffer'
 import {
   createMonacoInjectionHighlighter,
-  type MonacoInjectionHighlighterApi,
+  type MonacoInjectionHighlighterApi
 } from '@lex/monaco-inline-injections'
 import { PreviewPane } from './PreviewPane'
 import { WelcomeView } from './WelcomeView'
@@ -87,7 +87,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
     onCursorChange,
     exportStatus,
     onActivate,
-    contextMenuHandlers,
+    contextMenuHandlers
   },
   ref
 ) {
@@ -412,7 +412,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(function
       getEditor: () => editorRef.current?.getEditor() ?? null,
       getInjectionHighlighter: () => injectionHighlighterRef.current,
       find: handleFind,
-      replace: handleReplace,
+      replace: handleReplace
     }),
     [handleSave, handleFormat, handleFind, handleReplace, currentFile]
   )

--- a/src/components/FileContextMenu.tsx
+++ b/src/components/FileContextMenu.tsx
@@ -42,8 +42,8 @@ export function FileContextMenu({ position, onClose, handlers }: FileContextMenu
       ...fileActions,
       revealInFolder: {
         ...fileActions.revealInFolder,
-        label: revealLabel,
-      },
+        label: revealLabel
+      }
     }
   }, [position, isMac, isWindows])
 
@@ -123,7 +123,7 @@ export function FileContextMenu({ position, onClose, handlers }: FileContextMenu
     { ...actions.shareWhatsApp, separator: true },
     { ...actions.copyPath, separator: false, shortcut: isMac ? '⌘P' : 'Ctrl+P' },
     { ...actions.copyRelativePath, separator: false, shortcut: isMac ? '⇧⌘P' : 'Ctrl+Shift+P' },
-    { ...actions.revealInFolder, separator: false },
+    { ...actions.revealInFolder, separator: false }
   ]
 
   return (

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -9,14 +9,14 @@ import {
   FileCode,
   File,
   ChevronRight,
-  ChevronDown,
+  ChevronDown
 } from 'lucide-react'
 import { FILE_TREE_REFRESH_EVENT } from '@/lib/events'
 import { useSettings } from '@/contexts/SettingsContext'
 import {
   FileContextMenu,
   type FileContextMenuHandlers,
-  type FileContextMenuPosition,
+  type FileContextMenuPosition
 } from './FileContextMenu'
 
 interface FileEntry {
@@ -74,7 +74,7 @@ export function FileTree({
   rootPath,
   selectedFile,
   onFileSelect,
-  contextMenuHandlers,
+  contextMenuHandlers
 }: FileTreeProps) {
   const [files, setFiles] = useState<FileEntry[]>([])
   const [contextMenu, setContextMenu] = useState<FileContextMenuPosition | null>(null)
@@ -235,7 +235,7 @@ export function FileTree({
       ...contextMenuHandlers,
       onRevealInFolder: (filePath: string) => {
         window.ipcRenderer.showItemInFolder(filePath)
-      },
+      }
     }),
     [contextMenuHandlers]
   )
@@ -265,7 +265,7 @@ export function FileTree({
             data-selected={isSelected}
             style={{
               paddingLeft: `calc(var(--panel-item-padding) + ${depth * 12}px)`,
-              paddingRight: 'var(--panel-item-padding)',
+              paddingRight: 'var(--panel-item-padding)'
             }}
             onClick={(e) => {
               e.stopPropagation()
@@ -314,7 +314,7 @@ export function FileTree({
         <div
           style={{
             paddingTop: 'var(--panel-item-padding)',
-            paddingBottom: 'var(--panel-item-padding)',
+            paddingBottom: 'var(--panel-item-padding)'
           }}
         >
           {renderTree(files)}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -23,7 +23,7 @@ import {
   AlignLeft,
   Lightbulb,
   Image,
-  FileCode2,
+  FileCode2
 } from 'lucide-react'
 import { isLexFile } from '@/lib/files'
 import type { FileContextMenuHandlers } from './FileContextMenu'
@@ -81,7 +81,7 @@ export function Layout({
   onInsertAsset,
   onInsertVerbatim,
   onTriggerAction,
-  fileContextMenuHandlers,
+  fileContextMenuHandlers
 }: LayoutProps) {
   const isCurrentFileLex = isLexFile(currentFile ?? null)
   const hasCurrentFile = Boolean(currentFile)

--- a/src/components/LspErrorModal.tsx
+++ b/src/components/LspErrorModal.tsx
@@ -15,7 +15,7 @@ export function LspErrorModal({
   message,
   suggestion,
   onClose,
-  autoDismissMs = 15000,
+  autoDismissMs = 15000
 }: LspErrorModalProps) {
   useEffect(() => {
     if (!isOpen) return

--- a/src/components/Outline.tsx
+++ b/src/components/Outline.tsx
@@ -13,7 +13,7 @@ import {
   AtSign,
   FileText,
   Code,
-  Circle,
+  Circle
 } from 'lucide-react'
 
 interface DocumentSymbol {
@@ -43,7 +43,7 @@ const SymbolKind = {
   ARRAY: 18, // List
   OBJECT: 19, // ListItem
   STRUCT: 23, // Definition
-  EVENT: 24, // Annotation
+  EVENT: 24 // Annotation
 } as const
 
 /** Get icon for LSP symbol kind */
@@ -132,7 +132,7 @@ export function Outline({ currentFile, editor, cursorLine }: OutlineProps) {
       try {
         const uri = Uri.file(currentFile).toString()
         const response = await lspClient.sendRequest('textDocument/documentSymbol', {
-          textDocument: { uri },
+          textDocument: { uri }
         })
 
         if (Array.isArray(response)) {
@@ -180,7 +180,7 @@ export function Outline({ currentFile, editor, cursorLine }: OutlineProps) {
     // Navigate to the symbol's selection range (more precise than range)
     const position = {
       lineNumber: symbol.selectionRange.start.line + 1, // Monaco uses 1-based lines
-      column: symbol.selectionRange.start.character + 1,
+      column: symbol.selectionRange.start.character + 1
     }
 
     editor.setPosition(position)
@@ -211,7 +211,7 @@ export function Outline({ currentFile, editor, cursorLine }: OutlineProps) {
               paddingLeft: `calc(var(--panel-item-padding) + ${depth * 12}px)`,
               paddingRight: 'var(--panel-item-padding)',
               paddingTop: '2px',
-              paddingBottom: '2px',
+              paddingBottom: '2px'
             }}
             title={item.name}
             onClick={() => handleSymbolClick(item)}
@@ -255,7 +255,7 @@ export function Outline({ currentFile, editor, cursorLine }: OutlineProps) {
         <div
           style={{
             paddingTop: 'var(--panel-item-padding)',
-            paddingBottom: 'var(--panel-item-padding)',
+            paddingBottom: 'var(--panel-item-padding)'
           }}
         >
           {renderSymbols(symbols)}

--- a/src/components/PaneWorkspace.tsx
+++ b/src/components/PaneWorkspace.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
   type Dispatch,
-  type SetStateAction,
+  type SetStateAction
 } from 'react'
 import type { PaneState, PaneRowState } from '@/panes/types'
 import {
@@ -14,7 +14,7 @@ import {
   MIN_PANE_SIZE,
   getPaneWeight,
   getRowSize,
-  normalizePaneSizes,
+  normalizePaneSizes
 } from '@/panes/layout'
 import { EditorPane, type EditorPaneHandle } from './EditorPane'
 import type { ExportStatus } from './StatusBar'
@@ -72,7 +72,7 @@ export function PaneWorkspace({
   onFileLoaded,
   onCursorChange,
   onPaneRowsChange,
-  fileContextMenuHandlers,
+  fileContextMenuHandlers
 }: PaneWorkspaceProps) {
   const workspaceRef = useRef<HTMLDivElement>(null)
   const rowRefs = useRef(new Map<string, HTMLDivElement | null>())
@@ -99,7 +99,7 @@ export function PaneWorkspace({
         initialFirstSize: getRowSize(row),
         initialSecondSize: getRowSize(nextRow),
         totalRowSize,
-        containerHeight,
+        containerHeight
       })
     },
     [paneRows]
@@ -119,7 +119,7 @@ export function PaneWorkspace({
         startX: clientX,
         rowWidth,
         initialLeftSize: paneSizes[leftPaneId] ?? DEFAULT_PANE_SIZE,
-        initialRightSize: paneSizes[rightPaneId] ?? DEFAULT_PANE_SIZE,
+        initialRightSize: paneSizes[rightPaneId] ?? DEFAULT_PANE_SIZE
       })
     },
     [paneRows]

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -19,7 +19,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   const tabs = [
     { id: 'ui' as const, label: 'UI' },
     { id: 'formatter' as const, label: 'Formatter' },
-    { id: 'spellcheck' as const, label: 'Spellcheck' },
+    { id: 'spellcheck' as const, label: 'Spellcheck' }
   ]
   const indentSpaces = Math.max(1, localFormatterSettings.indentString.length || 4)
 
@@ -68,7 +68,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
     await Promise.all([
       updateEditorSettings(localEditorSettings),
       updateFormatterSettings(localFormatterSettings),
-      updateSpellcheckSettings(localSpellcheckSettings),
+      updateSpellcheckSettings(localSpellcheckSettings)
     ])
     onClose()
   }
@@ -144,7 +144,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalEditorSettings((prev) => ({
                           ...prev,
-                          rulerWidth: parseInt(e.target.value) || 0,
+                          rulerWidth: parseInt(e.target.value) || 0
                         }))
                       }
                       className="w-20 px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary disabled:opacity-50"
@@ -192,7 +192,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                         onChange={(e) =>
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            sessionBlankLinesBefore: Math.max(1, parseInt(e.target.value) || 1),
+                            sessionBlankLinesBefore: Math.max(1, parseInt(e.target.value) || 1)
                           }))
                         }
                         className="mt-1 w-full px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary"
@@ -213,7 +213,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                         onChange={(e) =>
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            sessionBlankLinesAfter: Math.max(1, parseInt(e.target.value) || 1),
+                            sessionBlankLinesAfter: Math.max(1, parseInt(e.target.value) || 1)
                           }))
                         }
                         className="mt-1 w-full px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary"
@@ -234,7 +234,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                         onChange={(e) =>
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            maxBlankLines: Math.max(1, parseInt(e.target.value) || 1),
+                            maxBlankLines: Math.max(1, parseInt(e.target.value) || 1)
                           }))
                         }
                         className="mt-1 w-full px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary"
@@ -256,7 +256,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                           const next = Math.max(1, parseInt(e.target.value) || 1)
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            indentString: ' '.repeat(next),
+                            indentString: ' '.repeat(next)
                           }))
                         }}
                         className="mt-1 w-full px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary"
@@ -285,7 +285,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalFormatterSettings((prev) => ({
                           ...prev,
-                          unorderedSeqMarker: e.target.value.slice(0, 1),
+                          unorderedSeqMarker: e.target.value.slice(0, 1)
                         }))
                       }
                       className="mt-1 w-full px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary"
@@ -301,7 +301,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                         onChange={(e) =>
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            normalizeSeqMarkers: e.target.checked,
+                            normalizeSeqMarkers: e.target.checked
                           }))
                         }
                         className="accent-primary"
@@ -315,7 +315,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                         onChange={(e) =>
                           setLocalFormatterSettings((prev) => ({
                             ...prev,
-                            normalizeVerbatimMarkers: e.target.checked,
+                            normalizeVerbatimMarkers: e.target.checked
                           }))
                         }
                         className="accent-primary"
@@ -336,7 +336,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalFormatterSettings((prev) => ({
                           ...prev,
-                          preserveTrailingBlanks: e.target.checked,
+                          preserveTrailingBlanks: e.target.checked
                         }))
                       }
                       className="accent-primary"
@@ -356,7 +356,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalFormatterSettings((prev) => ({
                           ...prev,
-                          formatOnSave: e.target.checked,
+                          formatOnSave: e.target.checked
                         }))
                       }
                       className="accent-primary"
@@ -384,7 +384,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalSpellcheckSettings((prev) => ({
                           ...prev,
-                          enabled: e.target.checked,
+                          enabled: e.target.checked
                         }))
                       }
                       className="accent-primary"
@@ -405,7 +405,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                       onChange={(e) =>
                         setLocalSpellcheckSettings((prev) => ({
                           ...prev,
-                          language: e.target.value,
+                          language: e.target.value
                         }))
                       }
                       className="w-40 px-2 py-1 text-sm bg-input border border-border rounded focus:outline-none focus:border-primary disabled:opacity-50"

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -27,7 +27,7 @@ export function StatusBar({ editor, exportStatus, onVimStatusNodeChange }: Statu
     line: 1,
     column: 1,
     selected: 0,
-    selectedLines: 0,
+    selectedLines: 0
   })
   const { settings, updateSpellcheckSettings, updateEditorSettings } = useSettings()
   const [isSpellMenuOpen, setIsSpellMenuOpen] = useState(false)
@@ -65,14 +65,14 @@ export function StatusBar({ editor, exportStatus, onVimStatusNodeChange }: Statu
           line: position.lineNumber,
           column: position.column,
           selected,
-          selectedLines,
+          selectedLines
         })
       }
     }
 
     const disposables = [
       editor.onDidChangeCursorPosition(updateCursor),
-      editor.onDidChangeCursorSelection(updateCursor),
+      editor.onDidChangeCursorSelection(updateCursor)
     ]
 
     updateCursor()

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 import {
   FileContextMenu,
   type FileContextMenuHandlers,
-  type FileContextMenuPosition,
+  type FileContextMenuPosition
 } from './FileContextMenu'
 
 export interface Tab {
@@ -48,7 +48,7 @@ export function TabBar({
   onTabSelect,
   onTabClose,
   onTabDrop,
-  contextMenuHandlers,
+  contextMenuHandlers
 }: TabBarProps) {
   const [isDragOver, setIsDragOver] = useState(false)
   const [contextMenu, setContextMenu] = useState<FileContextMenuPosition | null>(null)
@@ -70,7 +70,7 @@ export function TabBar({
       ...contextMenuHandlers,
       onRevealInFolder: (filePath: string) => {
         window.ipcRenderer.showItemInFolder(filePath)
-      },
+      }
     }),
     [contextMenuHandlers]
   )
@@ -81,7 +81,7 @@ export function TabBar({
         TAB_DRAG_TYPE,
         JSON.stringify({
           tabPath: tab.path,
-          sourcePaneId: paneId,
+          sourcePaneId: paneId
         })
       )
       e.dataTransfer.effectAllowed = 'copyMove'
@@ -118,7 +118,7 @@ export function TabBar({
         onTabDrop?.({
           tabPath: data.tabPath,
           sourcePaneId: data.sourcePaneId,
-          duplicate: e.altKey || e.metaKey,
+          duplicate: e.altKey || e.metaKey
         })
       } catch {
         // Invalid data, ignore

--- a/src/components/TrustPromptModal.tsx
+++ b/src/components/TrustPromptModal.tsx
@@ -35,7 +35,7 @@ export function TrustPromptModal() {
         // Same fail-closed behaviour as click-outside.
         trustPromptCoordinator.resolveCurrent({
           decision: 'denied',
-          reason: `Trust prompt for namespace \`${ns}\` was dismissed without a decision.`,
+          reason: `Trust prompt for namespace \`${ns}\` was dismissed without a decision.`
         })
       }
     }
@@ -52,7 +52,7 @@ export function TrustPromptModal() {
   const handleDeny = () => {
     trustPromptCoordinator.resolveCurrent({
       decision: 'denied',
-      reason: `User denied trust for namespace \`${params.namespace}\` in this workspace.`,
+      reason: `User denied trust for namespace \`${params.namespace}\` in this workspace.`
     })
   }
   const handleDismiss = () => {
@@ -61,7 +61,7 @@ export function TrustPromptModal() {
     // above, which routes to the same outcome.
     trustPromptCoordinator.resolveCurrent({
       decision: 'denied',
-      reason: `Trust prompt for namespace \`${params.namespace}\` was dismissed without a decision.`,
+      reason: `Trust prompt for namespace \`${params.namespace}\` was dismissed without a decision.`
     })
   }
 

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -33,7 +33,7 @@ export function WelcomeView() {
 function ShortcutRow({
   icon,
   label,
-  keys,
+  keys
 }: {
   icon: React.ReactNode
   label: string

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -5,7 +5,7 @@ import {
   EditorSettings,
   FormatterSettings,
   defaultAppSettings,
-  defaultFileTreeSettings,
+  defaultFileTreeSettings
 } from '@/settings/types'
 import { setSettingsSnapshot } from '@/settings/snapshot'
 
@@ -65,21 +65,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
           fileTree: {
             ...defaultFileTreeSettings,
             ...prev.fileTree,
-            ...(loadedSettings?.fileTree ?? {}),
+            ...(loadedSettings?.fileTree ?? {})
           },
           keybindings: {
             overrides: {
               ...prev.keybindings.overrides,
-              ...(loadedSettings?.keybindings?.overrides ?? {}),
-            },
+              ...(loadedSettings?.keybindings?.overrides ?? {})
+            }
           },
-          lastFolder: loadedSettings?.lastFolder,
+          lastFolder: loadedSettings?.lastFolder
         } satisfies AppSettings
         setSettingsSnapshot(next)
 
         // Disable LSP-side spellcheck (now handled client-side)
         lspClient.sendNotification('workspace/didChangeConfiguration', {
-          settings: { spellcheck: { enabled: false } },
+          settings: { spellcheck: { enabled: false } }
         })
 
         // Initialize client-side spellcheck
@@ -99,15 +99,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
           fileTree: {
             ...defaultFileTreeSettings,
             ...prev.fileTree,
-            ...(newSettings?.fileTree ?? {}),
+            ...(newSettings?.fileTree ?? {})
           },
           keybindings: {
             overrides: {
               ...prev.keybindings.overrides,
-              ...(newSettings?.keybindings?.overrides ?? {}),
-            },
+              ...(newSettings?.keybindings?.overrides ?? {})
+            }
           },
-          lastFolder: newSettings?.lastFolder,
+          lastFolder: newSettings?.lastFolder
         } satisfies AppSettings
         setSettingsSnapshot(next)
 
@@ -167,7 +167,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         updateEditorSettings,
         updateFormatterSettings,
         updateSpellcheckSettings,
-        updateFileTreeSettings,
+        updateFileTreeSettings
       }}
     >
       {children}

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -26,7 +26,7 @@ import type { SemanticTokens } from '@lex/monaco-inline-injections'
 const wasmUrls = import.meta.glob<string>('../resources/embedded-grammars/*/parser.wasm', {
   eager: true,
   query: '?url',
-  import: 'default',
+  import: 'default'
 })
 const highlightSources = import.meta.glob<string>(
   '../resources/embedded-grammars/*/highlights.scm',
@@ -74,7 +74,7 @@ const LEGEND_TYPES = [
   'struct',
   'typeParameter',
   'namespace',
-  'operator',
+  'operator'
 ] as const
 
 function langFromPath(p: string): string | null {
@@ -238,6 +238,6 @@ export function createEmbeddedTokenizer(): EmbeddedTokenizer {
       loaded.clear()
       inflight.clear()
       failed.clear()
-    },
+    }
   }
 }

--- a/src/features/__tests__/editing.test.ts
+++ b/src/features/__tests__/editing.test.ts
@@ -3,7 +3,7 @@ import {
   calculateSnippetInsertion,
   isSnippetInsertionPayload,
   isPreparePasteResponse,
-  computePasteEndPosition,
+  computePasteEndPosition
 } from '@/lib/editing'
 
 describe('Editing Logic', () => {

--- a/src/features/__tests__/navigation.test.ts
+++ b/src/features/__tests__/navigation.test.ts
@@ -8,8 +8,8 @@ describe('Navigation Logic', () => {
         uri: 'file:///tmp/foo.lex',
         range: {
           start: { line: 1, character: 1 },
-          end: { line: 1, character: 5 },
-        },
+          end: { line: 1, character: 5 }
+        }
       }
       expect(isLocation(valid)).toBe(true)
     })

--- a/src/features/__tests__/smartPaste.test.ts
+++ b/src/features/__tests__/smartPaste.test.ts
@@ -6,8 +6,8 @@ const sendRequest = vi.fn()
 vi.mock('@lex-fmt/lex-buffer', () => ({
   lspClient: {
     sendRequest: (...args: unknown[]) => sendRequest(...args),
-    hasExperimentalCapability: () => true,
-  },
+    hasExperimentalCapability: () => true
+  }
 }))
 
 // `monaco-editor` is a heavy ESM module; stub the surface `editing.ts` uses
@@ -28,7 +28,7 @@ vi.mock('monaco-editor', () => ({
       public positionLineNumber: number,
       public positionColumn: number
     ) {}
-  },
+  }
 }))
 
 import { applySmartPaste } from '../editing'
@@ -56,7 +56,7 @@ function makeEditor() {
     pushUndoStop: () => {
       undoStops += 1
       return true
-    },
+    }
   }
   return {
     editor: editor as unknown as Parameters<typeof applySmartPaste>[0],
@@ -64,7 +64,7 @@ function makeEditor() {
     undoStops: () => undoStops,
     swapModel: () => {
       model = { uri: { toString: () => 'file:///other.lex' } }
-    },
+    }
   }
 }
 
@@ -85,7 +85,7 @@ describe('applySmartPaste', () => {
       textDocument: { uri: 'file:///doc.lex' },
       // Monaco 1-indexed (2,5) → LSP 0-indexed (1,4)
       range: { start: { line: 1, character: 4 }, end: { line: 1, character: 4 } },
-      pastedText: 'pasted',
+      pastedText: 'pasted'
     })
   })
 

--- a/src/features/editing.ts
+++ b/src/features/editing.ts
@@ -5,7 +5,7 @@ import {
   calculateSnippetInsertion,
   isPreparePasteResponse,
   computePasteEndPosition,
-  type SnippetInsertionPayload,
+  type SnippetInsertionPayload
 } from '@/lib/editing'
 
 async function invokeInsertCommand(
@@ -27,8 +27,8 @@ async function invokeInsertCommand(
         arguments: [
           model.uri.toString(),
           { line: position.lineNumber - 1, character: position.column - 1 },
-          ...args,
-        ],
+          ...args
+        ]
       }
     )
 
@@ -70,8 +70,8 @@ function insertSnippet(
         position.column
       ),
       text: textToInsert,
-      forceMoveMarkers: true,
-    },
+      forceMoveMarkers: true
+    }
   ])
 
   const newPosition = model.getPositionAt(newCursorOffset)
@@ -208,7 +208,7 @@ async function applyExtractWorkspaceEdit(
           e.range.end.character + 1
         ),
         text: e.newText,
-        forceMoveMarkers: true,
+        forceMoveMarkers: true
       }))
       editor.executeEdits('lex-extract-to-include', monacoEdits)
       continue
@@ -261,19 +261,19 @@ export async function extractToInclude(
   const range: LspRange = {
     start: {
       line: selection.startLineNumber - 1,
-      character: selection.startColumn - 1,
+      character: selection.startColumn - 1
     },
     end: {
       line: selection.endLineNumber - 1,
-      character: selection.endColumn - 1,
-    },
+      character: selection.endColumn - 1
+    }
   }
 
   const response = await lspClient.sendRequest<LspWorkspaceEdit | null>(
     'workspace/executeCommand',
     {
       command: 'lex.extractToInclude',
-      arguments: [model.uri.toString(), range, src],
+      arguments: [model.uri.toString(), range, src]
     }
   )
   if (!response) throw new Error('Extract returned an empty response')
@@ -321,12 +321,12 @@ export async function applySmartPaste(
   const range: LspRange = {
     start: {
       line: pasteRange.startLineNumber - 1,
-      character: pasteRange.startColumn - 1,
+      character: pasteRange.startColumn - 1
     },
     end: {
       line: pasteRange.endLineNumber - 1,
-      character: pasteRange.endColumn - 1,
-    },
+      character: pasteRange.endColumn - 1
+    }
   }
 
   let response: unknown
@@ -334,7 +334,7 @@ export async function applySmartPaste(
     response = await lspClient.sendRequest<unknown>('lex/preparePaste', {
       textDocument: { uri: model.uri.toString() },
       range,
-      pastedText,
+      pastedText
     })
   } catch (error) {
     console.error('lex/preparePaste failed; falling back to native paste', error)
@@ -376,8 +376,8 @@ export async function applySmartPaste(
             pasteRange.endColumn
           ),
           text: response.text,
-          forceMoveMarkers: true,
-        },
+          forceMoveMarkers: true
+        }
       ],
       [new monaco.Selection(end.lineNumber, end.column, end.lineNumber, end.column)]
     )
@@ -432,7 +432,7 @@ export function installSmartPasteInterceptor(
       startLineNumber: selection.startLineNumber,
       startColumn: selection.startColumn,
       endLineNumber: selection.endLineNumber,
-      endColumn: selection.endColumn,
+      endColumn: selection.endColumn
     }
 
     void applySmartPaste(editor, pasteRange, pastedText).then((handled) => {
@@ -458,8 +458,8 @@ export function installSmartPasteInterceptor(
                 live.endColumn
               ),
               text: pastedText,
-              forceMoveMarkers: true,
-            },
+              forceMoveMarkers: true
+            }
           ],
           [new monaco.Selection(end.lineNumber, end.column, end.lineNumber, end.column)]
         )

--- a/src/features/interop.ts
+++ b/src/features/interop.ts
@@ -24,7 +24,7 @@ export async function exportContent(
 
   const result = await lspClient.sendRequest<string>('workspace/executeCommand', {
     command: 'lex.export',
-    arguments: args,
+    arguments: args
   })
 
   if (typeof result !== 'string') {
@@ -40,7 +40,7 @@ export async function exportContent(
 export async function importContent(content: string, format: ImportFormat): Promise<string> {
   const result = await lspClient.sendRequest<string>('workspace/executeCommand', {
     command: 'lex.import',
-    arguments: [format, content],
+    arguments: [format, content]
   })
 
   if (typeof result !== 'string') {

--- a/src/features/navigation.ts
+++ b/src/features/navigation.ts
@@ -19,8 +19,8 @@ async function invokeNavigationCommand(
       command,
       arguments: [
         model.uri.toString(),
-        { line: position.lineNumber - 1, character: position.column - 1 },
-      ],
+        { line: position.lineNumber - 1, character: position.column - 1 }
+      ]
     })
 
     if (isLocation(response)) {

--- a/src/features/preview.ts
+++ b/src/features/preview.ts
@@ -15,7 +15,7 @@ export const createPreviewTab = (sourceFile: string, content: string): PreviewTa
     name: `Preview: ${fileName}`,
     type: 'preview',
     previewContent: content,
-    sourceFile,
+    sourceFile
   }
 }
 
@@ -34,7 +34,7 @@ export function placePreviewTab({
   previewTab,
   setPanes,
   setPaneRows,
-  setActivePaneId,
+  setActivePaneId
 }: PreviewWorkspaceOptions) {
   if (panes.length === 1) {
     const newPane = createEmptyPane()
@@ -72,13 +72,13 @@ export function placePreviewTab({
         return {
           ...pane,
           tabs: pane.tabs.map((tab) => (tab.id === previewTab.id ? previewTab : tab)),
-          activeTabId: previewTab.id,
+          activeTabId: previewTab.id
         }
       }
       return {
         ...pane,
         tabs: [...pane.tabs, previewTab],
-        activeTabId: previewTab.id,
+        activeTabId: previewTab.id
       }
     })
   )

--- a/src/hooks/useLexTestBridge.ts
+++ b/src/hooks/useLexTestBridge.ts
@@ -28,7 +28,7 @@ export function useLexTestBridge({
   panesRef,
   panes,
   openFileInPane,
-  setRootPath,
+  setRootPath
 }: UseLexTestBridgeOptions) {
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -107,8 +107,8 @@ export function useLexTestBridge({
             endLineNumber: 1,
             endColumn: lastColumn,
             message: 'Mock diagnostic for testing',
-            source: 'lex-test',
-          },
+            source: 'lex-test'
+          }
         ])
         return true
       },
@@ -195,7 +195,7 @@ export function useLexTestBridge({
         const model = editorInstance?.getModel?.()
         if (!model) return null
         return lspClient.sendRequest('textDocument/foldingRange', {
-          textDocument: { uri: model.uri.toString() },
+          textDocument: { uri: model.uri.toString() }
         })
       },
       requestDocumentLinks: async () => {
@@ -203,7 +203,7 @@ export function useLexTestBridge({
         const model = editorInstance?.getModel?.()
         if (!model) return null
         return lspClient.sendRequest('textDocument/documentLink', {
-          textDocument: { uri: model.uri.toString() },
+          textDocument: { uri: model.uri.toString() }
         })
       },
       requestReferences: async (line: number, column: number) => {
@@ -213,7 +213,7 @@ export function useLexTestBridge({
         return lspClient.sendRequest('textDocument/references', {
           textDocument: { uri: model.uri.toString() },
           position: { line: line - 1, character: column - 1 },
-          context: { includeDeclaration: true },
+          context: { includeDeclaration: true }
         })
       },
       requestHover: async (line: number, column: number) => {
@@ -222,7 +222,7 @@ export function useLexTestBridge({
         if (!model) return null
         return lspClient.sendRequest('textDocument/hover', {
           textDocument: { uri: model.uri.toString() },
-          position: { line: line - 1, character: column - 1 },
+          position: { line: line - 1, character: column - 1 }
         })
       },
       requestCodeActions: async (
@@ -244,15 +244,15 @@ export function useLexTestBridge({
         if (!model) return null
         const range = diagnostic?.range ?? {
           start: { line: line - 1, character: column - 1 },
-          end: { line: line - 1, character: column - 1 },
+          end: { line: line - 1, character: column - 1 }
         }
         return lspClient.sendRequest('textDocument/codeAction', {
           textDocument: { uri: model.uri.toString() },
           range,
           context: {
             diagnostics: diagnostic ? [diagnostic] : [],
-            only: ['quickfix'],
-          },
+            only: ['quickfix']
+          }
         })
       },
       // Append text to the active model via `executeEdits`, mirroring
@@ -270,8 +270,8 @@ export function useLexTestBridge({
           {
             range: new monaco.Range(lastLine, lastColumn, lastLine, lastColumn),
             text,
-            forceMoveMarkers: true,
-          },
+            forceMoveMarkers: true
+          }
         ])
         return insertedFirstLine
       },
@@ -312,8 +312,8 @@ export function useLexTestBridge({
                   e.range.end.line + 1,
                   e.range.end.character + 1
                 ),
-                text: e.newText,
-              },
+                text: e.newText
+              }
             ])
           }
         }
@@ -362,7 +362,7 @@ export function useLexTestBridge({
         if (!highlighter) return false
         await highlighter.refresh()
         return true
-      },
+      }
     }
     window.__e2e.bridge = api
     return () => {

--- a/src/hooks/useMenuHandlers.ts
+++ b/src/hooks/useMenuHandlers.ts
@@ -47,7 +47,7 @@ export function useMenuHandlers(handlers: MenuHandlers) {
     onReorderFootnotes,
     onToggleHiddenFiles,
     onOpenFilePath,
-    onShowShortcuts,
+    onShowShortcuts
   } = handlers
 
   useEffect(() => {
@@ -225,6 +225,6 @@ export function useMenuHandlers(handlers: MenuHandlers) {
     onReorderFootnotes,
     onOpenFilePath,
     onShowShortcuts,
-    onToggleHiddenFiles,
+    onToggleHiddenFiles
   ])
 }

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -8,7 +8,7 @@ const paneFocusDefinitions: KeybindingDefinition[] = Array.from({ length: 9 }).m
     description: 'Focus a specific editor pane based on its visual order',
     category: 'Workspace',
     contexts: ['workspace'],
-    shortcut: `cmd+${position}`,
+    shortcut: `cmd+${position}`
   }
 })
 
@@ -19,7 +19,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Move focus to the next tab (cycles across panes)',
     category: 'Navigation',
     contexts: ['workspace'],
-    shortcut: 'cmd+shift+]',
+    shortcut: 'cmd+shift+]'
   },
   {
     id: 'workspace.tab.previous',
@@ -27,7 +27,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Move focus to the previous tab (cycles across panes)',
     category: 'Navigation',
     contexts: ['workspace'],
-    shortcut: 'cmd+shift+[',
+    shortcut: 'cmd+shift+['
   },
   ...paneFocusDefinitions,
   {
@@ -36,7 +36,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Split the active pane into a new horizontal row',
     category: 'Workspace',
     contexts: ['workspace'],
-    shortcut: 'cmd+shift+h',
+    shortcut: 'cmd+shift+h'
   },
   {
     id: 'workspace.pane.split.vertical',
@@ -44,7 +44,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Split the active pane side-by-side',
     category: 'Workspace',
     contexts: ['workspace'],
-    shortcut: 'cmd+shift+v',
+    shortcut: 'cmd+shift+v'
   },
   {
     id: 'editor.showReplace',
@@ -52,7 +52,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Open the replace UI in the active editor',
     category: 'Editor',
     contexts: ['editor'],
-    shortcut: 'cmd+r',
+    shortcut: 'cmd+r'
   },
   {
     id: 'commandPalette.show',
@@ -60,7 +60,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Toggle the LexEd command palette',
     category: 'General',
     contexts: ['global', 'modal'],
-    shortcut: 'cmd+k',
+    shortcut: 'cmd+k'
   },
   {
     id: 'workspace.shortcuts.show',
@@ -68,7 +68,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Display all available keyboard shortcuts',
     category: 'General',
     contexts: ['global', 'modal'],
-    shortcut: 'cmd+shift+/',
+    shortcut: 'cmd+shift+/'
   },
   {
     id: 'file.copyPath',
@@ -76,7 +76,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Copy the absolute path of the current file to clipboard',
     category: 'File',
     contexts: ['editor'],
-    shortcut: 'cmd+p',
+    shortcut: 'cmd+p'
   },
   {
     id: 'file.copyRelativePath',
@@ -84,7 +84,7 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
     description: 'Copy the relative path of the current file to clipboard',
     category: 'File',
     contexts: ['editor'],
-    shortcut: 'cmd+shift+p',
+    shortcut: 'cmd+shift+p'
   },
   {
     id: 'editor.extractToInclude',
@@ -93,6 +93,6 @@ export const KEYBINDING_DEFINITIONS: KeybindingDefinition[] = [
       'Split the current selection into a new include file referenced via :: lex.include ::',
     category: 'Editor',
     contexts: ['editor'],
-    shortcut: 'cmd+shift+e',
-  },
+    shortcut: 'cmd+shift+e'
+  }
 ]

--- a/src/keybindings/manager.test.ts
+++ b/src/keybindings/manager.test.ts
@@ -8,15 +8,15 @@ const definitions: KeybindingDefinition[] = [
     title: 'Workspace Action',
     category: 'Test',
     contexts: ['workspace'],
-    shortcut: 'cmd+1',
+    shortcut: 'cmd+1'
   },
   {
     id: 'modal.only',
     title: 'Modal Only',
     category: 'Test',
     contexts: ['modal'],
-    shortcut: 'cmd+k',
-  },
+    shortcut: 'cmd+k'
+  }
 ]
 
 describe('KeybindingManager', () => {
@@ -33,7 +33,7 @@ describe('KeybindingManager', () => {
       metaKey: true,
       ctrlKey: false,
       altKey: false,
-      shiftKey: false,
+      shiftKey: false
     }
     expect(manager.handleEvent(event)).toBeNull()
     manager.setContext('workspace', true)
@@ -50,7 +50,7 @@ describe('KeybindingManager', () => {
       metaKey: false,
       ctrlKey: true,
       altKey: false,
-      shiftKey: false,
+      shiftKey: false
     })
     expect(match?.id).toBe('workspace.action')
     expect(match?.shortcut.display).toBe('Ctrl+1')
@@ -65,7 +65,7 @@ describe('KeybindingManager', () => {
       metaKey: true,
       ctrlKey: false,
       altKey: false,
-      shiftKey: false,
+      shiftKey: false
     })
     expect(match).toBeNull()
   })
@@ -79,7 +79,7 @@ describe('KeybindingManager', () => {
       metaKey: true,
       ctrlKey: false,
       altKey: false,
-      shiftKey: false,
+      shiftKey: false
     }
     expect(manager.handleEvent(workspaceEvent)).toBeNull()
 
@@ -89,7 +89,7 @@ describe('KeybindingManager', () => {
       metaKey: true,
       ctrlKey: false,
       altKey: false,
-      shiftKey: false,
+      shiftKey: false
     }
     const match = manager.handleEvent(modalEvent)
     expect(match?.id).toBe('modal.only')

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -5,7 +5,7 @@ import type {
   KeybindingEventInput,
   KeybindingMatch,
   KeybindingRuntimeOptions,
-  ParsedShortcut,
+  ParsedShortcut
 } from './types'
 import { getShortcutVariants, parseShortcut } from './parser'
 
@@ -99,7 +99,7 @@ export class KeybindingManager {
         title: definition.title,
         description: definition.description,
         category: definition.category,
-        shortcuts,
+        shortcuts
       }
       this.descriptors.set(definition.id, descriptor)
 
@@ -110,7 +110,7 @@ export class KeybindingManager {
         list.push({
           id: definition.id,
           contexts: definition.contexts?.length ? definition.contexts : ['global'],
-          shortcut,
+          shortcut
         })
         this.bindingsByCode.set(chord.code, list)
       }

--- a/src/keybindings/parser.test.ts
+++ b/src/keybindings/parser.test.ts
@@ -178,7 +178,7 @@ describe('parseShortcut', () => {
         ['home', 'Home', 'Home'],
         ['end', 'End', 'End'],
         ['pageup', 'PageUp', 'PageUp'],
-        ['pagedown', 'PageDown', 'PageDown'],
+        ['pagedown', 'PageDown', 'PageDown']
       ]
       for (const [token, code, label] of cases) {
         const parsed = parseShortcut(`cmd+${token}`, 'mac')
@@ -288,7 +288,7 @@ describe('getShortcutVariants', () => {
       'cmd+a',
       { mac: 'cmd+b', windows: 'ctrl+b', linux: 'ctrl+b' },
       { mac: null, windows: 'ctrl+c', linux: 'ctrl+c' },
-      '',
+      ''
     ]
     expect(getShortcutVariants(shortcut, 'mac')).toEqual(['cmd+a', 'cmd+b'])
     expect(getShortcutVariants(shortcut, 'windows')).toEqual(['cmd+a', 'ctrl+b', 'ctrl+c'])

--- a/src/keybindings/parser.ts
+++ b/src/keybindings/parser.ts
@@ -36,14 +36,14 @@ const SPECIAL_KEY_CODES: Record<string, { code: string; label: string }> = {
   home: { code: 'Home', label: 'Home' },
   end: { code: 'End', label: 'End' },
   pageup: { code: 'PageUp', label: 'PageUp' },
-  pagedown: { code: 'PageDown', label: 'PageDown' },
+  pagedown: { code: 'PageDown', label: 'PageDown' }
 }
 
 const MODIFIER_ORDER: Array<keyof NormalizedKeyChord['modifiers']> = [
   'meta',
   'ctrl',
   'alt',
-  'shift',
+  'shift'
 ]
 
 const MODIFIER_LABELS: Record<
@@ -54,20 +54,20 @@ const MODIFIER_LABELS: Record<
     meta: 'Cmd',
     ctrl: 'Ctrl',
     alt: 'Option',
-    shift: 'Shift',
+    shift: 'Shift'
   },
   windows: {
     meta: 'Win',
     ctrl: 'Ctrl',
     alt: 'Alt',
-    shift: 'Shift',
+    shift: 'Shift'
   },
   linux: {
     meta: 'Super',
     ctrl: 'Ctrl',
     alt: 'Alt',
-    shift: 'Shift',
-  },
+    shift: 'Shift'
+  }
 }
 
 function normalizeToken(token: string): string {
@@ -152,7 +152,7 @@ export function parseShortcut(
     meta: false,
     ctrl: false,
     alt: false,
-    shift: false,
+    shift: false
   }
   let keyToken: string | null = null
 
@@ -202,11 +202,11 @@ export function parseShortcut(
   const chord: NormalizedKeyChord = {
     code: resolvedKey.code,
     keyLabel: resolvedKey.label,
-    modifiers,
+    modifiers
   }
 
   return {
     chords: [chord],
-    display: buildDisplayLabel(chord, platform),
+    display: buildDisplayLabel(chord, platform)
   }
 }

--- a/src/lib/editing.ts
+++ b/src/lib/editing.ts
@@ -34,7 +34,7 @@ export function calculateSnippetInsertion(
     textToInsert,
     prefix,
     suffix,
-    newCursorOffset,
+    newCursorOffset
   }
 }
 
@@ -58,7 +58,7 @@ const PREPARE_PASTE_MODES: ReadonlySet<string> = new Set<PreparePasteMode>([
   're-anchor',
   'passthrough-verbatim',
   'passthrough-table',
-  'passthrough-single-line',
+  'passthrough-single-line'
 ])
 
 /**

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -4,7 +4,7 @@ import {
   isLexFile,
   isMarkdownFile,
   getFileActions,
-  type FileActionId,
+  type FileActionId
 } from '@/lib/files'
 
 describe('getLanguageForFile', () => {
@@ -98,7 +98,7 @@ describe('getFileActions', () => {
     'exportHtml',
     'preview',
     'format',
-    'shareWhatsApp',
+    'shareWhatsApp'
   ]
   const HAS_FILE: FileActionId[] = ['copyPath', 'copyRelativePath', 'revealInFolder']
 

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -72,47 +72,47 @@ export function getFileActions(path: string | null | undefined): FileActions {
     exportMarkdown: {
       id: 'exportMarkdown',
       label: 'Export to Markdown',
-      enabled: isLex,
+      enabled: isLex
     },
     exportHtml: {
       id: 'exportHtml',
       label: 'Export to HTML',
-      enabled: isLex,
+      enabled: isLex
     },
     preview: {
       id: 'preview',
       label: 'Preview',
-      enabled: isLex,
+      enabled: isLex
     },
     convertToLex: {
       id: 'convertToLex',
       label: 'Convert to Lex',
-      enabled: isMd,
+      enabled: isMd
     },
     format: {
       id: 'format',
       label: 'Format Document',
-      enabled: isLex,
+      enabled: isLex
     },
     shareWhatsApp: {
       id: 'shareWhatsApp',
       label: 'Share via WhatsApp',
-      enabled: isLex,
+      enabled: isLex
     },
     copyPath: {
       id: 'copyPath',
       label: 'Copy Path',
-      enabled: hasFile,
+      enabled: hasFile
     },
     copyRelativePath: {
       id: 'copyRelativePath',
       label: 'Copy Relative Path',
-      enabled: hasFile,
+      enabled: hasFile
     },
     revealInFolder: {
       id: 'revealInFolder',
       label: 'Reveal in Finder',
-      enabled: hasFile,
-    },
+      enabled: hasFile
+    }
   }
 }

--- a/src/lsp/ipc-connection.ts
+++ b/src/lsp/ipc-connection.ts
@@ -3,7 +3,7 @@ import {
   AbstractMessageWriter,
   Message,
   Disposable,
-  DataCallback,
+  DataCallback
 } from 'vscode-jsonrpc'
 
 interface IpcRenderer {

--- a/src/lsp/trustPromptCoordinator.test.ts
+++ b/src/lsp/trustPromptCoordinator.test.ts
@@ -13,7 +13,7 @@ function fakeParams(namespace = 'acme'): TrustRequestParams {
     command_string: '/bin/handler',
     source: { kind: 'lex_toml', name: namespace },
     capability: 'full',
-    transport: 'subprocess',
+    transport: 'subprocess'
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,7 @@ window.__e2e = {
     if (this.events.length > MAX_E2E_EVENTS) {
       this.events.splice(0, this.events.length - MAX_E2E_EVENTS)
     }
-  },
+  }
 }
 
 import React from 'react'
@@ -24,7 +24,7 @@ import {
   initializeMonaco,
   lspClient,
   setLspTransportFactory,
-  configureHost,
+  configureHost
 } from '@lex-fmt/lex-buffer'
 import { trustPromptCoordinator } from './lsp/trustPromptCoordinator'
 import { PlatformProvider } from './contexts/PlatformContext'
@@ -46,10 +46,10 @@ configureHost({
   logger: log,
   e2e: {
     signal: (name, payload) => window.__e2e.signal(name, payload),
-    notifyFormattingRequest: (payload) => window.__e2e.bridge.notifyFormattingRequest?.(payload),
+    notifyFormattingRequest: (payload) => window.__e2e.bridge.notifyFormattingRequest?.(payload)
   },
   onLexModelReady: (model) => spellcheckService.scheduleCheck(model),
-  onLexModelChange: (model) => spellcheckService.scheduleCheck(model),
+  onLexModelChange: (model) => spellcheckService.scheduleCheck(model)
 })
 
 // Update the e2e ready flag when the LSP signals readiness — the

--- a/src/panes/layout.ts
+++ b/src/panes/layout.ts
@@ -50,5 +50,5 @@ export const withRowDefaults = (row: PaneRowState): PaneRowState => ({
   id: row.id,
   paneIds: [...row.paneIds],
   size: row.size && row.size > 0 ? row.size : DEFAULT_ROW_SIZE,
-  paneSizes: normalizePaneSizes(row),
+  paneSizes: normalizePaneSizes(row)
 })

--- a/src/panes/usePaneManager.ts
+++ b/src/panes/usePaneManager.ts
@@ -8,7 +8,7 @@ import {
   MIN_ROW_SIZE,
   getRowSize,
   normalizePaneSizes,
-  withRowDefaults,
+  withRowDefaults
 } from './layout'
 import type { Tab, TabDropData } from '@/components/TabBar'
 
@@ -25,7 +25,7 @@ export function usePaneManager({
   setActivePaneId,
   setPanes,
   setPaneRows,
-  createTabFromPath,
+  createTabFromPath
 }: UsePaneManagerOptions) {
   const focusPane = useCallback(
     (paneId: string) => {
@@ -124,7 +124,7 @@ export function usePaneManager({
       if (prevRows.length === 0) {
         return [
           withRowDefaults({ id: createRowId(), paneIds: [activePaneId] }),
-          withRowDefaults({ id: createRowId(), paneIds: [newPane.id] }),
+          withRowDefaults({ id: createRowId(), paneIds: [newPane.id] })
         ]
       }
       let handled = false
@@ -143,7 +143,7 @@ export function usePaneManager({
             id: createRowId(),
             paneIds: [newPane.id],
             size: rowSize,
-            paneSizes: { [newPane.id]: DEFAULT_PANE_SIZE },
+            paneSizes: { [newPane.id]: DEFAULT_PANE_SIZE }
           })
         )
       })
@@ -237,7 +237,7 @@ export function usePaneManager({
             tabs: remainingTabs,
             activeTabId: nextActiveId,
             currentFile: remainingTabs.length === 0 ? null : pane.currentFile,
-            cursorLine: remainingTabs.length === 0 ? 0 : pane.cursorLine,
+            cursorLine: remainingTabs.length === 0 ? 0 : pane.cursorLine
           }
           if (remainingTabs.length === 0 && prev.length > 1) {
             removePane = true
@@ -281,7 +281,7 @@ export function usePaneManager({
             return {
               ...pane,
               tabs: [...pane.tabs, newTab],
-              activeTabId: newTab.id,
+              activeTabId: newTab.id
             }
           }
           if (pane.id === sourcePaneId && !duplicate) {
@@ -299,7 +299,7 @@ export function usePaneManager({
               tabs: remainingTabs,
               activeTabId: nextActiveId,
               currentFile: remainingTabs.length === 0 ? null : pane.currentFile,
-              cursorLine: remainingTabs.length === 0 ? 0 : pane.cursorLine,
+              cursorLine: remainingTabs.length === 0 ? 0 : pane.cursorLine
             }
           }
           return pane
@@ -352,6 +352,6 @@ export function usePaneManager({
     handleTabClose,
     handleTabDrop,
     handlePaneFileLoaded,
-    handlePaneCursorChange,
+    handlePaneCursorChange
   }
 }

--- a/src/panes/usePersistedPaneLayout.ts
+++ b/src/panes/usePersistedPaneLayout.ts
@@ -25,7 +25,7 @@ export const createEmptyPane = (id?: string): PaneState => ({
   tabs: [],
   activeTabId: null,
   currentFile: null,
-  cursorLine: 0,
+  cursorLine: 0
 })
 
 interface DefaultLayout {
@@ -61,7 +61,7 @@ const hydrateSavedRows = (savedRows: SavedPaneRow[], paneIdSet: Set<string>): Pa
         ? row.paneIds.filter((id: string) => paneIdSet.has(id))
         : [],
       size: typeof row.size === 'number' ? row.size : undefined,
-      paneSizes: row.paneSizes && typeof row.paneSizes === 'object' ? row.paneSizes : undefined,
+      paneSizes: row.paneSizes && typeof row.paneSizes === 'object' ? row.paneSizes : undefined
     }))
     .filter((row) => row.paneIds.length > 0)
 
@@ -81,11 +81,11 @@ const buildDefaultLayout = (): DefaultLayout => {
         size: DEFAULT_ROW_SIZE,
         paneSizes: {
           [first.id]: DEFAULT_PANE_SIZE,
-          [second.id]: DEFAULT_PANE_SIZE,
-        },
-      },
+          [second.id]: DEFAULT_PANE_SIZE
+        }
+      }
     ],
-    activePaneId: first.id,
+    activePaneId: first.id
   }
 }
 
@@ -119,7 +119,7 @@ export function usePersistedPaneLayout(
                 ? pane.activeTab
                 : pane.tabs[0] || null,
             currentFile: null,
-            cursorLine: 0,
+            cursorLine: 0
           }))
 
           if (hydrated.length === 1) {
@@ -138,7 +138,7 @@ export function usePersistedPaneLayout(
           } else if (unreferenced.length > 0) {
             rows[0] = {
               ...rows[0],
-              paneIds: [...rows[0].paneIds, ...unreferenced],
+              paneIds: [...rows[0].paneIds, ...unreferenced]
             }
           }
 
@@ -176,13 +176,13 @@ export function usePersistedPaneLayout(
         const payload = panes.map((pane) => ({
           id: pane.id,
           tabs: pane.tabs.map((tab) => tab.path),
-          activeTab: pane.activeTabId,
+          activeTab: pane.activeTabId
         }))
         const rowsPayload = paneRows.map((row) => ({
           id: row.id,
           paneIds: row.paneIds.filter((id) => panes.some((p) => p.id === id)),
           size: row.size,
-          paneSizes: row.paneSizes,
+          paneSizes: row.paneSizes
         }))
         await window.ipcRenderer.setOpenTabs(payload, rowsPayload, resolvedActivePaneId)
       } catch (error) {
@@ -208,6 +208,6 @@ export function usePersistedPaneLayout(
     setActivePaneId,
     layoutInitialized,
     resolvedActivePane,
-    resolvedActivePaneId,
+    resolvedActivePaneId
   }
 }

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -42,7 +42,7 @@ import type {
   FormatterSettings,
   SpellcheckSettings,
   PaneLayout,
-  Unsubscribe,
+  Unsubscribe
 } from '@lex/shared'
 import { IpcMessageReader, IpcMessageWriter } from '@/lsp/ipc-connection'
 
@@ -81,7 +81,7 @@ const fileSystemAdapter: FileSystemAdapter = {
 
   async showInFolder(path: string): Promise<void> {
     await window.ipcRenderer.showItemInFolder(path)
-  },
+  }
 }
 
 // ============================================================================
@@ -95,7 +95,7 @@ const themeAdapter: ThemeAdapter = {
 
   onChange(callback: (theme: ThemeMode) => void): Unsubscribe {
     return window.ipcRenderer.onNativeThemeChanged(callback)
-  },
+  }
 }
 
 // ============================================================================
@@ -129,7 +129,7 @@ const settingsAdapter: SettingsAdapter = {
 
   async getInitialFolder(): Promise<string | null> {
     return window.ipcRenderer.getInitialFolder()
-  },
+  }
 }
 
 // ============================================================================
@@ -140,13 +140,13 @@ const lspAdapter: LspAdapter = {
   createTransport(): LspTransport {
     return {
       reader: new IpcMessageReader(window.ipcRenderer),
-      writer: new IpcMessageWriter(window.ipcRenderer),
+      writer: new IpcMessageWriter(window.ipcRenderer)
     }
   },
 
   onStatus(callback: (status: LspStatus) => void): Unsubscribe {
     return window.ipcRenderer.onLspStatus(callback)
-  },
+  }
 }
 
 // ============================================================================
@@ -160,7 +160,7 @@ const persistenceAdapter: PersistenceAdapter = {
 
   async saveLayout(layout: PaneLayout): Promise<void> {
     await window.ipcRenderer.setOpenTabs(layout.panes, layout.rows, layout.activePaneId)
-  },
+  }
 }
 
 // ============================================================================
@@ -223,7 +223,7 @@ const commandsAdapter: CommandsAdapter = {
 
   updateMenuState(state: { hasOpenFile: boolean; isLexFile: boolean }): void {
     window.ipcRenderer.updateMenuState(state)
-  },
+  }
 }
 
 // ============================================================================
@@ -240,7 +240,7 @@ const toastAdapter: ToastAdapter = {
 
   onShow(callback: (type: 'success' | 'error' | 'info', message: string) => void): Unsubscribe {
     return window.ipcRenderer.onShowToast(callback)
-  },
+  }
 }
 
 // ============================================================================
@@ -261,5 +261,5 @@ export const electronAdapter: PlatformAdapter = {
   lsp: lspAdapter,
   persistence: persistenceAdapter,
   commands: commandsAdapter,
-  toast: toastAdapter,
+  toast: toastAdapter
 }

--- a/src/settings/snapshot.ts
+++ b/src/settings/snapshot.ts
@@ -4,7 +4,7 @@ import type {
   FormatterSettings,
   KeybindingSettings,
   SpellcheckSettings,
-  FileTreeSettings,
+  FileTreeSettings
 } from './types'
 import { defaultAppSettings } from './types'
 
@@ -15,15 +15,15 @@ let currentSettings: AppSettings = {
   fileTree: { ...defaultAppSettings.fileTree },
   keybindings: {
     ...defaultAppSettings.keybindings,
-    overrides: { ...defaultAppSettings.keybindings.overrides },
+    overrides: { ...defaultAppSettings.keybindings.overrides }
   },
-  lastFolder: defaultAppSettings.lastFolder,
+  lastFolder: defaultAppSettings.lastFolder
 }
 
 const cloneEditor = (editor: EditorSettings): EditorSettings => ({
   showRuler: editor.showRuler,
   rulerWidth: editor.rulerWidth,
-  vimMode: editor.vimMode,
+  vimMode: editor.vimMode
 })
 
 const cloneFormatter = (formatter: FormatterSettings): FormatterSettings => ({
@@ -35,20 +35,20 @@ const cloneFormatter = (formatter: FormatterSettings): FormatterSettings => ({
   indentString: formatter.indentString,
   preserveTrailingBlanks: formatter.preserveTrailingBlanks,
   normalizeVerbatimMarkers: formatter.normalizeVerbatimMarkers,
-  formatOnSave: formatter.formatOnSave,
+  formatOnSave: formatter.formatOnSave
 })
 
 const cloneSpellcheck = (spellcheck: SpellcheckSettings): SpellcheckSettings => ({
   enabled: spellcheck.enabled,
-  language: spellcheck.language,
+  language: spellcheck.language
 })
 
 const cloneKeybindings = (keybindings: KeybindingSettings): KeybindingSettings => ({
-  overrides: { ...keybindings.overrides },
+  overrides: { ...keybindings.overrides }
 })
 
 const cloneFileTree = (fileTree: FileTreeSettings): FileTreeSettings => ({
-  showHiddenFiles: fileTree.showHiddenFiles,
+  showHiddenFiles: fileTree.showHiddenFiles
 })
 
 const cloneSettings = (settings: AppSettings): AppSettings => ({
@@ -57,7 +57,7 @@ const cloneSettings = (settings: AppSettings): AppSettings => ({
   spellcheck: cloneSpellcheck(settings.spellcheck),
   fileTree: cloneFileTree(settings.fileTree),
   keybindings: cloneKeybindings(settings.keybindings),
-  lastFolder: settings.lastFolder,
+  lastFolder: settings.lastFolder
 })
 
 export function setSettingsSnapshot(settings: AppSettings): void {

--- a/src/settings/spellcheckLanguages.ts
+++ b/src/settings/spellcheckLanguages.ts
@@ -13,5 +13,5 @@ export const SPELLCHECK_LANGUAGES: SpellcheckLanguageOption[] = [
   { value: 'it_IT', label: 'Italian' },
   { value: 'ru_RU', label: 'Russian' },
   { value: 'nl_NL', label: 'Dutch' },
-  { value: 'pl_PL', label: 'Polish' },
+  { value: 'pl_PL', label: 'Polish' }
 ]

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -26,7 +26,7 @@ export interface FileTreeSettings {
 }
 
 export const defaultFileTreeSettings: FileTreeSettings = {
-  showHiddenFiles: false,
+  showHiddenFiles: false
 }
 
 export type KeybindingPlatform = 'mac' | 'windows' | 'linux'
@@ -53,7 +53,7 @@ export interface AppSettings {
 export const defaultEditorSettings: EditorSettings = {
   showRuler: false,
   rulerWidth: 100,
-  vimMode: false,
+  vimMode: false
 }
 
 export const defaultFormatterSettings: FormatterSettings = {
@@ -65,16 +65,16 @@ export const defaultFormatterSettings: FormatterSettings = {
   indentString: '    ',
   preserveTrailingBlanks: false,
   normalizeVerbatimMarkers: true,
-  formatOnSave: false,
+  formatOnSave: false
 }
 
 export const defaultSpellcheckSettings: SpellcheckSettings = {
   enabled: true,
-  language: 'en_US',
+  language: 'en_US'
 }
 
 export const defaultKeybindingSettings: KeybindingSettings = {
-  overrides: {},
+  overrides: {}
 }
 
 export const defaultAppSettings: AppSettings = {
@@ -83,5 +83,5 @@ export const defaultAppSettings: AppSettings = {
   spellcheck: defaultSpellcheckSettings,
   keybindings: defaultKeybindingSettings,
   fileTree: defaultFileTreeSettings,
-  lastFolder: undefined,
+  lastFolder: undefined
 }

--- a/src/spellcheck/__tests__/spellcheck-fixture.test.ts
+++ b/src/spellcheck/__tests__/spellcheck-fixture.test.ts
@@ -34,7 +34,7 @@ describe('spellcheck-fixture e2e', () => {
       ['Mispelled', 'list item / definition subject'],
       ['Brokn', 'table caption'],
       ['Coloumn', 'table header cell'],
-      ['Pythn', 'verbatim subject (prose per policy)'],
+      ['Pythn', 'verbatim subject (prose per policy)']
     ])('flags %s (%s)', (typo) => {
       expect(wordSet.has(typo)).toBe(true)
     })

--- a/src/spellcheck/__tests__/word-extraction.test.ts
+++ b/src/spellcheck/__tests__/word-extraction.test.ts
@@ -14,14 +14,14 @@ describe('extractCheckableWords', () => {
       startLine: 1,
       startColumn: 1,
       endLine: 1,
-      endColumn: 6,
+      endColumn: 6
     })
     expect(words[1]).toEqual({
       text: 'world',
       startLine: 1,
       startColumn: 7,
       endLine: 1,
-      endColumn: 12,
+      endColumn: 12
     })
   })
 
@@ -42,7 +42,7 @@ describe('extractCheckableWords', () => {
       '\tlet x = 42;',
       ':: rust ::',
       '',
-      'After',
+      'After'
     ].join('\n')
     const words = extractCheckableWords(text)
     expect(words.map((w) => w.text)).toEqual(['Before', 'Pythn', 'code', 'example', 'After'])
@@ -135,7 +135,7 @@ describe('extractCheckableWords', () => {
       '    let x = 42;',
       ':: rust ::',
       '',
-      'After',
+      'After'
     ].join('\n')
     const words = extractCheckableWords(text)
     expect(words.map((w) => w.text)).toEqual(['Before', 'Pythn', 'code', 'example', 'After'])
@@ -153,7 +153,7 @@ describe('extractCheckableWords', () => {
       'body',
       'This',
       'is',
-      'outside',
+      'outside'
     ])
   })
 })

--- a/src/spellcheck/service.ts
+++ b/src/spellcheck/service.ts
@@ -140,7 +140,7 @@ export class SpellcheckService {
           startColumn: word.startColumn,
           endLineNumber: word.endLine,
           endColumn: word.endColumn,
-          source: MARKER_OWNER,
+          source: MARKER_OWNER
         })
       }
     }
@@ -238,14 +238,14 @@ export class SpellcheckService {
                         startLineNumber: marker.startLineNumber,
                         startColumn: marker.startColumn,
                         endLineNumber: marker.endLineNumber,
-                        endColumn: marker.endColumn,
+                        endColumn: marker.endColumn
                       },
-                      text: suggestion,
+                      text: suggestion
                     },
-                    versionId: undefined,
-                  },
-                ],
-              },
+                    versionId: undefined
+                  }
+                ]
+              }
             })
           }
 
@@ -257,13 +257,13 @@ export class SpellcheckService {
             command: {
               id: 'lexed.spellcheck.addToDictionary',
               title: 'Add to dictionary',
-              arguments: [word, model.uri.toString()],
-            },
+              arguments: [word, model.uri.toString()]
+            }
           })
         }
 
         return { actions, dispose: () => {} }
-      },
+      }
     })
 
     // Register the "add to dictionary" command

--- a/src/spellcheck/word-extraction.ts
+++ b/src/spellcheck/word-extraction.ts
@@ -234,7 +234,7 @@ function computeSpellRanges(
           stack.push({
             spell: stackTopSpell(stack),
             openerIndent: c.indent,
-            bodyIndent: indentOf(lines[nextIdx]),
+            bodyIndent: indentOf(lines[nextIdx])
           })
         }
         // The opener line itself is just markers — skip words.
@@ -296,7 +296,7 @@ export function extractCheckableWords(text: string): CheckableWord[] {
           startLine: i + 1,
           startColumn: wordStart + 1,
           endLine: i + 1,
-          endColumn: wordStart + m[0].length + 1,
+          endColumn: wordStart + m[0].length + 1
         })
       }
     }

--- a/src/treesitter.ts
+++ b/src/treesitter.ts
@@ -57,7 +57,7 @@ export function initTreeSitter(): Promise<LexTreeSitter | null> {
 async function loadTreeSitter(): Promise<LexTreeSitter | null> {
   try {
     await Parser.init({
-      locateFile: () => runtimeWasmUrl,
+      locateFile: () => runtimeWasmUrl
     })
 
     const language = await Language.load(grammarWasmUrl)
@@ -90,7 +90,7 @@ async function loadTreeSitter(): Promise<LexTreeSitter | null> {
           startCol: c.node.startPosition.column,
           endRow: c.node.endPosition.row,
           endCol: c.node.endPosition.column,
-          text: c.node.text,
+          text: c.node.text
         }))
       },
 
@@ -121,9 +121,9 @@ async function loadTreeSitter(): Promise<LexTreeSitter | null> {
                 startCol: capture.node.startPosition.column,
                 endRow: capture.node.endPosition.row,
                 endCol: capture.node.endPosition.column,
-                text: capture.node.text,
+                text: capture.node.text
               },
-              parentId,
+              parentId
             })
           } else if (capture.name === 'injection.language') {
             const raw = capture.node.text.trim()
@@ -146,7 +146,7 @@ async function loadTreeSitter(): Promise<LexTreeSitter | null> {
               startCol: cc.node.startCol,
               endRow: cc.node.endRow,
               endCol: cc.node.endCol,
-              text: cc.node.text,
+              text: cc.node.text
             })
           }
         }
@@ -158,7 +158,7 @@ async function loadTreeSitter(): Promise<LexTreeSitter | null> {
         parser.delete()
         highlightsQuery.delete()
         injectionsQuery?.delete()
-      },
+      }
     }
   } catch (err) {
     console.warn('[lex] Failed to initialize tree-sitter:', err)
@@ -181,6 +181,6 @@ export function createLexZoneProvider(ts: LexTreeSitter): InjectionZoneProvider 
       } finally {
         tree.delete()
       }
-    },
+    }
   }
 }

--- a/tests/e2e/completion.spec.ts
+++ b/tests/e2e/completion.spec.ts
@@ -4,7 +4,7 @@ import {
   focusEditor,
   expectNoCompletionItem,
   expectCompletionItem,
-  openWorkspace,
+  openWorkspace
 } from './lib'
 import { openFixture } from './helpers'
 import path from 'node:path'
@@ -26,7 +26,7 @@ test.describe('Path completion', () => {
     const workspace = await openWorkspace(page, [
       { relativePath: 'notes/entry.lex', content: '# Entry File\n\nThis is a test document.\n' },
       { relativePath: 'assets/image.png', content: 'fake-image' },
-      { relativePath: '.gitignore', content: '' },
+      { relativePath: '.gitignore', content: '' }
     ])
 
     try {

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -3,7 +3,7 @@ import {
   waitForEditorContent,
   focusEditor,
   expectEditorValue,
-  triggerCompletion,
+  triggerCompletion
 } from './lib'
 import { openFixture } from './helpers'
 

--- a/tests/e2e/file-routing.spec.ts
+++ b/tests/e2e/file-routing.spec.ts
@@ -28,12 +28,12 @@ type LaunchHandle = {
 async function launchReady(userData: string): Promise<LaunchHandle> {
   const app = await launchApp({
     env: { E2E_DISABLE_PERSISTENCE: '0' },
-    extraArgs: [`--user-data-dir=${userData}`],
+    extraArgs: [`--user-data-dir=${userData}`]
   })
   const page = await app.firstWindow()
   await page.waitForLoadState('domcontentloaded')
   await page.waitForFunction(() => window.__e2e?.ready?.app === true, null, {
-    timeout: 15000,
+    timeout: 15000
   })
   return { app, page }
 }
@@ -218,7 +218,7 @@ test.describe('File routing & workspace persistence', () => {
       const newPage = await newWindowPromise
       await newPage.waitForLoadState('domcontentloaded')
       await newPage.waitForFunction(() => window.__e2e?.ready?.app === true, null, {
-        timeout: 15000,
+        timeout: 15000
       })
       await newPage.waitForFunction(
         (expected) => (window as Window).__lexWorkspaceRoot === expected,

--- a/tests/e2e/format.spec.ts
+++ b/tests/e2e/format.spec.ts
@@ -10,7 +10,7 @@ const FORMATTER_SETTINGS = {
   indentString: '    ',
   preserveTrailingBlanks: false,
   normalizeVerbatimMarkers: true,
-  formatOnSave: false,
+  formatOnSave: false
 }
 
 const EXPECTED_PROPERTIES = {
@@ -21,7 +21,7 @@ const EXPECTED_PROPERTIES = {
   'lex.max_blank_lines': 2,
   'lex.indent_string': '    ',
   'lex.preserve_trailing_blanks': false,
-  'lex.normalize_verbatim_markers': true,
+  'lex.normalize_verbatim_markers': true
 }
 
 test.describe('Format Document', () => {
@@ -43,8 +43,8 @@ test.describe('Format Document', () => {
       options: {
         tabSize: 4,
         insertSpaces: true,
-        ...EXPECTED_PROPERTIES,
-      },
+        ...EXPECTED_PROPERTIES
+      }
     })
     expect(request?.type).toBe('document')
   })

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -12,6 +12,6 @@ export default async function globalSetup() {
 
   execSync('npm run build', {
     cwd: ROOT,
-    stdio: 'inherit',
+    stdio: 'inherit'
   })
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -43,7 +43,7 @@ export async function launchApp(options: AppLaunchOptions = {}) {
     NODE_ENV: useBuiltRenderer ? 'production' : 'development',
     E2E_DISABLE_SINGLE_INSTANCE_LOCK: '1',
     ...envOverrides,
-    E2E_USER_DATA_DIR: callerProvidedDir ?? autoCreatedDir,
+    E2E_USER_DATA_DIR: callerProvidedDir ?? autoCreatedDir
   }
 
   if (!env.E2E_HIDE_WINDOW) {
@@ -63,7 +63,7 @@ export async function launchApp(options: AppLaunchOptions = {}) {
 
   const app = await electron.launch({
     args: ['.', ...extraArgs],
-    env,
+    env
   })
   app.process().stdout?.on('data', (data) => console.log(`Electron stdout: ${data}`))
   app.process().stderr?.on('data', (data) => console.log(`Electron stderr: ${data}`))

--- a/tests/e2e/injection-highlighting.spec.ts
+++ b/tests/e2e/injection-highlighting.spec.ts
@@ -76,7 +76,7 @@ test.describe('Injection Highlighting', () => {
         },
         {
           timeout: 20_000,
-          message: 'Waiting for tree-sitter to detect every bundled-language zone',
+          message: 'Waiting for tree-sitter to detect every bundled-language zone'
         }
       )
       .toBe(BUNDLED_LANGUAGES.length)
@@ -103,7 +103,7 @@ test.describe('Injection Highlighting', () => {
           }),
         {
           timeout: 30_000,
-          message: 'Waiting for embedded-grammar:tokens signal from every bundled language',
+          message: 'Waiting for embedded-grammar:tokens signal from every bundled language'
         }
       )
       .toBe(BUNDLED_LANGUAGES.length)
@@ -113,7 +113,7 @@ test.describe('Injection Highlighting', () => {
       return {
         zones: api.getInjectionZones() as InjectionZone[],
         ranges: api.getInjectionRanges() as InjectionRange[],
-        byCategory: api.getInjectionRangesByCategory() as Record<string, InjectionRange[]>,
+        byCategory: api.getInjectionRangesByCategory() as Record<string, InjectionRange[]>
       }
     })
 

--- a/tests/e2e/label-policy.spec.ts
+++ b/tests/e2e/label-policy.spec.ts
@@ -65,20 +65,20 @@ test.describe('Label policy', () => {
         message: 'doc.table',
         severity: 'error',
         startLineNumber: DOC_TABLE_LINE,
-        source: 'lex',
+        source: 'lex'
       },
       {
         message: 'doc.unknownthing',
         severity: 'error',
         startLineNumber: DOC_UNKNOWNTHING_LINE,
-        source: 'lex',
+        source: 'lex'
       },
       {
         message: 'lex.notarealsemantic',
         severity: 'error',
         startLineNumber: LEX_NOTREAL_LINE,
-        source: 'lex',
-      },
+        source: 'lex'
+      }
     ])
   })
 
@@ -113,12 +113,12 @@ test.describe('Label policy', () => {
       return {
         range: {
           start: { line: marker.startLineNumber - 1, character: marker.startColumn - 1 },
-          end: { line: marker.endLineNumber - 1, character: marker.endColumn - 1 },
+          end: { line: marker.endLineNumber - 1, character: marker.endColumn - 1 }
         },
         severity: marker.severity,
         code: marker.code,
         source: marker.source,
-        message: marker.message,
+        message: marker.message
       }
     }, DOC_TABLE_LINE)
 
@@ -169,7 +169,7 @@ test.describe('Label policy', () => {
       // Position just inside the label token (after `:: `, which is 3 chars).
       { line: 15, column: 4, expect: 'Shortcut for' }, // :: title ::
       { line: 17, column: 4, expect: 'Prefix-stripped form' }, // :: metadata.author ::
-      { line: 19, column: 4, expect: 'Community label' }, // :: acme.task ::
+      { line: 19, column: 4, expect: 'Community label' } // :: acme.task ::
     ]
 
     for (const c of cases) {

--- a/tests/e2e/lib/actions.ts
+++ b/tests/e2e/lib/actions.ts
@@ -74,7 +74,7 @@ const DEFAULT_FORMATTER = {
   indentString: '    ',
   preserveTrailingBlanks: false,
   normalizeVerbatimMarkers: true,
-  formatOnSave: false,
+  formatOnSave: false
 }
 const DEFAULT_SPELLCHECK = { enabled: true, language: 'en_US' }
 
@@ -140,6 +140,6 @@ export async function openWorkspace(
       } catch {
         // Ignore cleanup failures
       }
-    },
+    }
   }
 }

--- a/tests/e2e/lib/app.ts
+++ b/tests/e2e/lib/app.ts
@@ -33,7 +33,7 @@ export type AppFixtures = {
 }
 
 const defaultAppLaunchOptions: AppLaunchOptions = {
-  env: { E2E_DISABLE_PERSISTENCE: '1' },
+  env: { E2E_DISABLE_PERSISTENCE: '1' }
 }
 
 /**
@@ -60,7 +60,7 @@ const IGNORED_ERROR_PATTERNS: ReadonlyArray<string> = [
   //   asset that doesn't ship. Pre-existing; allowlisted so the
   //   harness lands. Track as its own bug once we've narrowed the
   //   missing resource.
-  'Failed to load resource: net::ERR_FILE_NOT_FOUND',
+  'Failed to load resource: net::ERR_FILE_NOT_FOUND'
 ]
 
 function shouldIgnore(message: string): boolean {
@@ -147,8 +147,8 @@ export const test = base.extend<AppFixtures>({
         )
       }
     },
-    { auto: true },
-  ],
+    { auto: true }
+  ]
 })
 
 export { expect } from '@playwright/test'

--- a/tests/e2e/lib/assertions.ts
+++ b/tests/e2e/lib/assertions.ts
@@ -43,7 +43,7 @@ export async function expectMarkers(page: Page, expected: MarkerMatch[], { timeo
         message: m.message,
         severity: m.severity,
         startLineNumber: m.startLineNumber,
-        source: m.source,
+        source: m.source
       }))
     })
 
@@ -89,7 +89,7 @@ export async function expectFormattingRequest(
   { timeout = 10000 } = {}
 ) {
   await page.waitForFunction(() => window.__e2e.bridge.getLastFormattingRequest?.() != null, null, {
-    timeout,
+    timeout
   })
   const request = (await page.evaluate(() => window.__e2e.bridge.getLastFormattingRequest?.())) as {
     type: 'document' | 'range'
@@ -117,21 +117,21 @@ export async function expectEditorValue(
     await expect
       .poll(() => page.evaluate(() => window.__e2e.bridge?.getActiveEditorValue() ?? ''), {
         timeout,
-        message: 'Waiting for editor value to match pattern',
+        message: 'Waiting for editor value to match pattern'
       })
       .toMatch(expected)
   } else if (exact) {
     await expect
       .poll(() => page.evaluate(() => window.__e2e.bridge?.getActiveEditorValue() ?? ''), {
         timeout,
-        message: 'Waiting for exact editor value',
+        message: 'Waiting for exact editor value'
       })
       .toBe(expected)
   } else {
     await expect
       .poll(() => page.evaluate(() => window.__e2e.bridge?.getActiveEditorValue() ?? ''), {
         timeout,
-        message: 'Waiting for editor value to contain text',
+        message: 'Waiting for editor value to contain text'
       })
       .toContain(expected)
   }

--- a/tests/e2e/lib/completion.ts
+++ b/tests/e2e/lib/completion.ts
@@ -18,7 +18,7 @@ type CompletionFilter = {
 function matchesFilter(item: CompletionItem, filter: CompletionFilter): boolean {
   for (const [key, expected] of Object.entries(filter) as [
     keyof CompletionFilter,
-    string | RegExp,
+    string | RegExp
   ][]) {
     const actual = item[key]
     if (actual === undefined) return false

--- a/tests/e2e/lib/index.ts
+++ b/tests/e2e/lib/index.ts
@@ -5,7 +5,7 @@ export {
   waitForLsp,
   waitForEditor,
   waitForEditorContent,
-  waitForSpellcheck,
+  waitForSpellcheck
 } from './wait'
 export * as loc from './locators'
 export {
@@ -14,7 +14,7 @@ export {
   expectFormattingRequest,
   expectEditorValue,
   expectToast,
-  assertNoRuntimeErrors,
+  assertNoRuntimeErrors
 } from './assertions'
 export {
   focusEditor,
@@ -22,12 +22,12 @@ export {
   openSettings,
   closeSettings,
   resetSettings,
-  openWorkspace,
+  openWorkspace
 } from './actions'
 export {
   triggerCompletion,
   getCompletionItems,
   expectCompletionItem,
   expectNoCompletionItem,
-  acceptCompletion,
+  acceptCompletion
 } from './completion'

--- a/tests/e2e/lib/wait.ts
+++ b/tests/e2e/lib/wait.ts
@@ -47,6 +47,6 @@ export async function waitForEditorContent(page: Page, text: string, { timeout =
  */
 export async function waitForSpellcheck(page: Page, timeout = 20000) {
   await page.waitForFunction(() => Boolean(window.__e2e.bridge.isSpellcheckReady?.()), null, {
-    timeout,
+    timeout
   })
 }

--- a/tests/e2e/no-errors-on-open.spec.ts
+++ b/tests/e2e/no-errors-on-open.spec.ts
@@ -19,7 +19,7 @@ import { focusEditor } from './lib/actions'
 test.describe('Runtime error sentinel', () => {
   test('opening a .lex document produces no pageerror or console.error', async ({
     page,
-    runtimeErrors,
+    runtimeErrors
   }) => {
     await openFixture(page, 'semantic-basic.lex')
     await focusEditor(page)

--- a/tests/e2e/packaged.spec.ts
+++ b/tests/e2e/packaged.spec.ts
@@ -38,7 +38,7 @@ import {
   test,
   type ConsoleMessage,
   type ElectronApplication,
-  type Page,
+  type Page
 } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -103,7 +103,7 @@ async function waitForEditorWindow(
   while (Date.now() - start < timeoutMs) {
     const remaining = timeoutMs - (Date.now() - start)
     const next = await application.waitForEvent('window', {
-      timeout: Math.max(remaining, 1000),
+      timeout: Math.max(remaining, 1000)
     })
     if (isEditor(next)) {
       await next.waitForLoadState('domcontentloaded')
@@ -136,8 +136,8 @@ test.beforeAll(async () => {
       ...process.env,
       LEX_LSP_PATH: '',
       E2E_HIDE_WINDOW: '',
-      E2E_DISABLE_PERSISTENCE: '',
-    },
+      E2E_DISABLE_PERSISTENCE: ''
+    }
   })
   page = await waitForEditorWindow(app)
   // Surface browser-side logs to the test runner's output so a CI
@@ -177,6 +177,6 @@ test('packaged app captures a screenshot of its initial state', async () => {
   const platform = process.env.PACKAGED_PLATFORM_LABEL ?? process.platform
   await page.screenshot({
     path: path.join(outDir, `${platform}-initial.png`),
-    fullPage: true,
+    fullPage: true
   })
 })

--- a/tests/e2e/semantic-tokens.spec.ts
+++ b/tests/e2e/semantic-tokens.spec.ts
@@ -10,7 +10,7 @@ test.describe('Semantic Tokens', () => {
     await expect
       .poll(() => page.evaluate(() => (window as any).__lexSemanticTokenCount ?? 0), {
         timeout: 15000,
-        message: 'Waiting for semantic tokens from LSP',
+        message: 'Waiting for semantic tokens from LSP'
       })
       .toBeGreaterThan(0)
   })

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -16,7 +16,7 @@ test.describe('Settings', () => {
       indentString: ' '.repeat(6),
       preserveTrailingBlanks: true,
       normalizeVerbatimMarkers: false,
-      formatOnSave: true,
+      formatOnSave: true
     }
 
     await page.evaluate(async (formatter) => {

--- a/tests/e2e/spellcheck.spec.ts
+++ b/tests/e2e/spellcheck.spec.ts
@@ -3,7 +3,7 @@ import { openFixture } from './helpers'
 
 test.describe('Spellcheck', () => {
   test('should show diagnostics for misspelled words and support language switching', async ({
-    page,
+    page
   }) => {
     test.setTimeout(90000)
 

--- a/tests/e2e/split-panes.spec.ts
+++ b/tests/e2e/split-panes.spec.ts
@@ -6,7 +6,7 @@ test.describe('Split Panes', () => {
 
     const workspace = await openWorkspace(page, [
       { relativePath: 'general.lex', content: '# General\nContent' },
-      { relativePath: '20-ideas-naked.lex', content: '# Ideas, Naked\nContent' },
+      { relativePath: '20-ideas-naked.lex', content: '# Ideas, Naked\nContent' }
     ])
 
     try {

--- a/tests/e2e/trust-prompt.spec.ts
+++ b/tests/e2e/trust-prompt.spec.ts
@@ -29,7 +29,7 @@ const sampleParams: TrustRequestParams = {
   command_string: '/usr/local/bin/acme-handler --serve',
   source: { kind: 'lex_toml', name: 'acme' },
   capability: 'full',
-  transport: 'subprocess',
+  transport: 'subprocess'
 }
 
 test.describe('lex/trustRequest modal', () => {
@@ -84,7 +84,7 @@ test.describe('lex/trustRequest modal', () => {
 
     // Modal closes after the click resolves the Promise.
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
-      timeout: 5000,
+      timeout: 5000
     })
     // Poll for the .then() callback to have populated __trustResp.
     // The microtask scheduling of Promise resolution doesn't
@@ -118,7 +118,7 @@ test.describe('lex/trustRequest modal', () => {
     await page.getByRole('button', { name: 'Deny' }).click()
 
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
-      timeout: 5000,
+      timeout: 5000
     })
     await page.waitForFunction(
       () =>
@@ -152,7 +152,7 @@ test.describe('lex/trustRequest modal', () => {
     await page.keyboard.press('Escape')
 
     await expect(page.getByText('Lex extension trust required')).not.toBeVisible({
-      timeout: 5000,
+      timeout: 5000
     })
     await page.waitForFunction(
       () =>


### PR DESCRIPTION
Part of the fleet lint-hermeticity epic (arthur-debert/shipit LNT01), workstream WS04 (arthur-debert/shipit#517): unify the 4 TypeScript repos onto one canonical `.prettierrc` and reformat.

## What changed
- **Commit 1** (`build(lint)`): replace the per-repo JSON `.prettierrc` with the fleet-canonical YAML body, **byte-identical** to `arthur-debert/shipit` `.prettierrc`. The only rule delta for lexed is `trailingComma: es5 -> none`; `semi: false`, `singleQuote`, `printWidth: 100`, `tabWidth: 2` already matched. The svelte/tailwind plugins in the canonical config are override-scoped to `*.svelte` and stay **inert** here (lexed has no `.svelte` files) — verified prettier loads the config with no plugin-load failure on the TS leg.
- **Commit 2** (`style(lint)`): mechanical `npm run format` (prettier --write over the repo's own format scope: `src`, `electron`, `tests`). 77 files, pure trailing-comma removal; a handful of multi-line arrow expressions re-fit on one line once the trailing comma is gone. **No hand edits.**

## eslint
No eslint changes needed: the config enforces no stylistic rules (`semi` / `comma-dangle` / `quotes` are all absent; `js.configs.recommended` and the tseslint recommended set don't include them), so there was no prettier/eslint conflict to resolve.

## Verification (green)
- `npm run format:check` — clean
- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm run test:unit` (vitest, 244 tests) — all pass

The full `electron-builder` package + e2e suite run in CI (they need the electron binary and grammar fetch-deps not present in the authoring sandbox, and are unaffected by trailing-comma formatting).

Coordinator note (arthur-debert/shipit#517): reformat commit is mechanical; no closing keyword by design.