### PR TITLE
fix(shipit): add npm test script + fix theme generator trailing commas (TOL01 exit sweep)

### DIFF
--- a/app-bin/gen-theme.py
+++ b/app-bin/gen-theme.py
@@ -17,9 +17,9 @@ runtime resolves) matches how every other editor in the workspace
 ships their theme: canonical → absolute hex at generate time.
 
 Output style matches lexed's prettier config (no semicolons, single
-quotes, tabWidth=2). Run after editing the canonical file. The npm
-`theme:check` script runs `gen-theme.py --check`; pre-commit and
-CI fail on stale output.
+quotes, tabWidth=2, trailingComma=none). Run after editing the canonical
+file. The npm `theme:check` script runs `gen-theme.py --check`;
+pre-commit and CI fail on stale output.
 """
 
 from __future__ import annotations
@@ -92,19 +92,24 @@ def validate_canonical(canonical: dict) -> None:
 def render_palette_block(canonical: dict, mode: str) -> str:
     intensities = canonical["intensities"]
     backgrounds = canonical["backgrounds"]
-    lines = []
+    # Join with ",\n" (rather than a trailing comma per line) so the last
+    # entry carries none — prettier's trailingComma=none, which theme-data.ts
+    # is held to by the managed lint gate.
+    entries = []
     for name in EXPECTED_INTENSITIES:
-        lines.append(f"    {name}: {s(intensities[name][mode])},")
+        entries.append(f"    {name}: {s(intensities[name][mode])}")
     for bg_name in EXPECTED_BACKGROUNDS:
-        lines.append(f"    {bg_name}: {s(backgrounds[bg_name][mode])},")
-    return "\n".join(lines)
+        entries.append(f"    {bg_name}: {s(backgrounds[bg_name][mode])}")
+    return ",\n".join(entries)
 
 
 def render_rules_block(canonical: dict, mode: str) -> str:
     intensities = canonical["intensities"]
     backgrounds = canonical["backgrounds"]
     tokens = canonical["tokens"]
-    lines: list[str] = []
+    # Join with ",\n" so the last rule carries no trailing comma
+    # (prettier trailingComma=none — see render_palette_block).
+    entries: list[str] = []
     for token_id, token in tokens.items():
         # Monaco token rules want hex without the leading '#'.
         fg = strip_hash(intensities[token["intensity"]][mode])
@@ -115,8 +120,8 @@ def render_rules_block(canonical: dict, mode: str) -> str:
         if "background" in token:
             bg = strip_hash(backgrounds[token["background"]][mode])
             fields.append(f"background: {s(bg)}")
-        lines.append("    { " + ", ".join(fields) + " },")
-    return "\n".join(lines)
+        entries.append("    { " + ", ".join(fields) + " }")
+    return ",\n".join(entries)
 
 
 def render(canonical: dict) -> str:
@@ -151,7 +156,7 @@ def render(canonical: dict) -> str:
         "  },\n"
         "  dark: {\n"
         f"{render_palette_block(canonical, 'dark')}\n"
-        "  },\n"
+        "  }\n"
         "}\n"
         "\n"
         "export const RULES: { light: TokenRule[]; dark: TokenRule[] } = {\n"
@@ -160,7 +165,7 @@ def render(canonical: dict) -> str:
         "  ],\n"
         "  dark: [\n"
         f"{render_rules_block(canonical, 'dark')}\n"
-        "  ],\n"
+        "  ]\n"
         "}\n"
     )
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e:built": "E2E_USE_BUILD=1 E2E_SKIP_BUILD=1 E2E_HIDE_WINDOW=1 PLAYWRIGHT_BROWSERS_PATH=0 E2E_DISABLE_PERSISTENCE=1 npx playwright test tests/e2e",
     "test:e2e:packaged": "E2E_SKIP_BUILD=1 npx playwright test --project=packaged",
     "test:e2e:ci": "npm run icons && npm run check-deps && tsc && vite build && E2E_USE_BUILD=1 E2E_SKIP_BUILD=1 E2E_HIDE_WINDOW=1 PLAYWRIGHT_BROWSERS_PATH=0 E2E_DISABLE_PERSISTENCE=1 xvfb-run -a playwright test tests/e2e",
+    "test": "npm run test:unit",
     "test:unit": "vitest",
     "dictionaries:update": "python3 app-bin/generate-dictionary-supplement.py && node app-bin/generate-tries.mjs",
     "dictionaries:update:force": "python3 app-bin/generate-dictionary-supplement.py --force && node app-bin/generate-tries.mjs --force",


### PR DESCRIPTION
Fixes two TOL01 exit-sweep reds for lex-fmt/lexed (gate arthur-debert/shipit#558).

## What changed

- **TEST red** — `shipit test` dispatches `npm test`, but `package.json` had no `test` script (only `test:unit`, `test:e2e:*`). Added `"test": "npm run test:unit"` so the fast, hermetic vitest unit suite is the canonical test surface. E2E stays in its own scripts/CI.
- **BUILD red** — `npm run build` failed in the `prebuild` `theme:check` gate. Root cause: `app-bin/gen-theme.py` emitted trailing commas, but the LNT01 lint reconciliation (commit 7bb4a8d, "reconcile managed lint config + clear debt") reformatted `packages/lex-buffer/src/monaco/theme-data.ts` to the managed prettier config's `trailingComma: none`. That left the generator's output permanently out of sync with the committed, prettier-clean file. Fixed the **generator** (not the output) to emit `trailingComma: none`, matching its own documented contract ("Output style matches lexed's prettier config").

## Context

- **Why fix the generator, not just regenerate.** The brief's suggested fix (run `gen-theme.py` and commit the regenerated file) trades one red for another: the regenerated file carries trailing commas that the managed prettier lint gate rejects (`theme:check` and prettier are mutually exclusive for that file). The genuine root cause is the generator drifting from the managed prettier config after LNT01. Fixing the generator satisfies **both** gates. As a bonus, the regenerated `theme-data.ts` is now byte-identical to the already-committed file, so no output-file change is in this diff — only `gen-theme.py` and `package.json`.
- **Governing docs checked.** shipit ADR-0007/0039 (test dispatches on the repo's declared toolchain → `npm test` must exist and be meaningful); the repo's own AGENTS.md managed dev-cycle block. The `test:unit` = `vitest` suite is the right hermetic-clone surface.
- **Verify output (on this branch, from a clean clone with `git submodule update --init`):**
  - `npm test` / `pixi run test` → 244 tests, 18 files, all pass (`TEST: OK (1 leg)`).
  - `npm run build` → exit 0; prebuild `theme:check` passes, tsc + vite build + electron-builder complete (produces `LexEd-0.11.2-arm64.dmg`).
  - `python3 app-bin/gen-theme.py --check` → exit 0 (file matches the fixed generator).
  - `shipit lint` (commit + push hooks) → OK, 9 checks including prettier over 178 web files.
- **Out of scope / do not re-open.** Did not change what `test:unit` runs, did not touch shipit-managed files (`bin/`, `lefthook.yml`, managed `pixi.toml`/`.shipit.toml` blocks), did not hand-edit the generated `theme-data.ts` (fix is in the generator). The e2e scripts and their CI are unchanged by design.

closes #<none — freeform sweep fix>