### PR TITLE
ci: adopt shipit release pipeline — electron declaration + blessed caller (ADP02-WS09)

### DIFF
--- a/.github/workflows/on-upstream-released.yml
+++ b/.github/workflows/on-upstream-released.yml
@@ -22,7 +22,13 @@ name: On upstream released
 
 on:
   repository_dispatch:
-    types: [upstream-released]
+    # BOTH event types, deliberately (ADP02-WS09 #172; coordinator note on
+    # arthur-debert/shipit#842): the legacy v3 cascade fires
+    # `upstream-released`, while shipit's notify-downstreams endpoint
+    # (shipit#824) fires `upstream-release`. lexed listens for both until
+    # the legacy cascade is retired — dropping the legacy type is that
+    # retirement's job, not this cutover's.
+    types: [upstream-released, upstream-release]
 
 permissions:
   contents: write

--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -1,0 +1,156 @@
+name: shipit-release
+
+# lexed's shipit release caller (ADP02-WS09, #172; workstream of
+# arthur-debert/shipit#842) — the WS09 BLESSED per-stage dispatch shape
+# (ADR-0054, workflows.lex §8), copied verbatim from shipit's own dogfooded
+# caller (shipit#806): one workflow_dispatch caller with a `stage` choice
+# (full | prepare | build | sign | publish), one job per stage, each a
+# single `uses:` line against the matching block, gated
+# `if: inputs.stage == '...'`, forwarding `version`/`tag`/`run-id`/
+# `unsigned` verbatim. Routing ONLY (ADR-0040): the release plan — matrix,
+# live stages, the post-RC-guard endpoint set, required secrets — is
+# preflight's, computed inside the blocks; nothing is re-derived or wired
+# stage-to-stage here.
+#
+# Every ref is the FULL remote `arthur-debert/shipit/...@v1` form — the
+# remote-ref scar (shipit legacy release RC #823): a `./` reusable-workflow
+# ref resolves against the top-level caller's repo, never shipit.
+#
+# lexed's release surface is the electron artifact (.shipit.toml
+# [artifacts.lexed], shipit#823's composition): the plan fans darwin-arm64 /
+# linux-x86_64 / windows-x86_64 build+bundle legs, and the darwin leg
+# (sign = true) routes through the STANDALONE mac-sign stage — the unsigned
+# .app reseal payload is reopened, resigned inner-first with per-code-role
+# JIT entitlements (shipit#833), resealed into the .dmg, and notarized. All
+# five stage choices stay offered (the blessed shape is never trimmed).
+# KNOWN: the windows leg is blocked on shipit#893 (win-importability) — the
+# rc proof is coordinator-sequenced after that fix.
+#
+# Secrets — exactly the plan-required set for lexed's plan:
+#   RELEASE_TOKEN               prepare's tag+branch push through the
+#                               ruleset (a GITHUB_TOKEN push would not
+#                               re-trigger workflows).
+#   APPLE_CERTIFICATE           ← the repo secret APPLE_CERTIFICATE_P12_BASE64
+#                               (the legacy spelling this repo already
+#                               provisions; shipit unified on
+#                               APPLE_CERTIFICATE — the mapping happens here,
+#                               at the caller's secrets boundary, never a
+#                               second repo secret).
+#   APPLE_CERTIFICATE_PASSWORD  same name legacy provisions.
+#   ASC_API_KEY_BASE64 / _ID / ASC_API_ISSUER_ID
+#                               the ASC notary trio, verbatim legacy names.
+# The Apple-ID notary trio (APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID) is NOT
+# forwarded: this repo provisions the ASC trio (either trio satisfies the
+# plan, shipit#746); the legacy APPLE_APP_SPECIFIC_PASSWORD secret stays
+# untouched for the legacy release.yml until its post-rc retirement.
+# gh-release rides the workflow's own GITHUB_TOKEN; there are no external
+# endpoints, so no endpoint token is forwarded.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          The release version, consumed by `full`/`prepare`: a bare semver
+          (1.0.0, 1.0.0-release-rc) or a bump word (major|minor|patch).
+          Ignored by the tag-dispatched stages.
+        required: false
+        type: string
+      stage:
+        description: >-
+          What to dispatch: the full composed chain (default) or ONE
+          independently re-runnable stage block (per-stage dispatch,
+          ADR-0054). `prepare` dispatches on `version`; `build`, `sign`
+          and `publish` on `tag` (+ `run-id` for the artifact-consuming
+          stages).
+        required: false
+        type: choice
+        default: full
+        options:
+          - full
+          - prepare
+          - build
+          - sign
+          - publish
+      tag:
+        description: >-
+          The release tag (v<version>), consumed by the `build`/`sign`/
+          `publish` stage dispatches (ADR-0041: the version is read off
+          the tag). Ignored by `full`/`prepare`.
+        required: false
+        type: string
+      run-id:
+        description: >-
+          The SOURCE run id whose artifacts feed an artifact-consuming
+          stage dispatch (`sign`, `publish`) — one source run per dispatch
+          (workflows.lex §8). Ignored by the other stages.
+        required: false
+        type: string
+      unsigned:
+        description: >-
+          Break-glass: flip a signing plan to the unsigned path. Forwarded
+          verbatim; lexed's plan signs the darwin leg, so this skips the
+          mac sign/notarize stage and publishes the unsigned set.
+        required: false
+        type: boolean
+        default: false
+
+# The standalone dispatch caller's grant (workflows.lex §8): `contents:
+# write` for prepare's push and publish's gh-release, `actions: read` for
+# the cross-run artifact downloads (`run-id` flips download-artifact onto
+# the REST API). The downloading blocks deliberately declare NO
+# `permissions:` key — a called workflow can only downgrade this token.
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    if: inputs.stage == 'full'
+    uses: arthur-debert/shipit/.github/workflows/wf-release.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+
+  prepare:
+    if: inputs.stage == 'prepare'
+    uses: arthur-debert/shipit/.github/workflows/wf-prepare.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  build:
+    if: inputs.stage == 'build'
+    uses: arthur-debert/shipit/.github/workflows/wf-build.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+
+  sign:
+    if: inputs.stage == 'sign'
+    uses: arthur-debert/shipit/.github/workflows/wf-sign-mac.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+    secrets:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+
+  publish:
+    if: inputs.stage == 'publish'
+    uses: arthur-debert/shipit/.github/workflows/wf-publish.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+      unsigned: ${{ inputs.unsigned }}

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -68,7 +68,51 @@ required = true
 local = true
 
 [toolchains]
-"." = "npm"
+# Per-path build override (ADP02-WS09, #172): the registry default (`npm run
+# build`) assumes a provisioned tree, but the wf-build block's checkout
+# provisions nothing beyond pixi (no node_modules, no comms submodule, no
+# fetch-deps artifacts — the same bare-runner premise the WS03 lanes
+# self-provision around). `build:release` (package.json) chains the
+# self-provisioning script (app-bin/release-provision.sh: comms submodule,
+# npm ci root + shared/, fetch-deps onto node_modules/.bin) into the ordinary
+# `npm run build`. A local `shipit build` runs the same path — reproducible,
+# lockfile-exact, like the test-full lane.
+"." = { toolchain = "npm", build = ["npm", "run", "build:release"] }
+
+# [artifacts] — the declared release surface (ADP02-WS09, #172; workstream of
+# arthur-debert/shipit#842). ONE electron artifact, the legacy v0.11.0 asset
+# set re-declared on shipit's electron composition (shipit#823 decision
+# record):
+#   - darwin-arm64: LexEd-<v>-arm64.dmg (+ .dmg.blockmap) — built UNSIGNED
+#     (electron-builder's own codesign/notarize stay OFF: no CSC_* env rides
+#     the build leg, package.json keeps `notarize: false`, and the afterPack
+#     appex hook skips without CSC_LINK), re-emitted as the unsigned-app
+#     reseal payload the STANDALONE mac-sign stage reopens → resigns
+#     inner-first with per-code-role JIT entitlements (shipit#833) → reseals
+#     the .dmg → notarizes. `sign = true` derives the Apple cert + notary
+#     secret requirement through the standard sign-stage path.
+#   - linux-x86_64: LexEd-<v>.AppImage (a blockmap is collected only when
+#     present — legacy shipped none). Ships unsigned, per legacy.
+#   - windows-x86_64: LexEd.Setup.<v>.exe (+ .exe.blockmap). Declared for
+#     legacy parity; the leg runs shipit on a windows runner and is BLOCKED
+#     on shipit#893 (win-importability) — the coordinator sequences the rc
+#     proof after that fix. Ships unsigned, per legacy.
+# The bundle command is `npm run dist` (bare electron-builder): the build
+# stage's `build:release` already compiled tsc/vite and ran electron-builder
+# once, so the bundle stage's declared-command run is an idempotent repackage
+# over the same compiled tree into `release/` (package.json
+# directories.output — distinct from the bundle output tree, as the
+# composition requires), which the composition then collects from.
+# `product-name` anchors assert-bundle's dmg/AppImage filename fallback tier;
+# the darwin reseal payload's CFBundleExecutable (LexEd) is the authoritative
+# tier.
+[artifacts.lexed]
+build = ["npm"]
+platforms = ["darwin-arm64", "linux-x86_64", "windows-x86_64"]
+bundle = { composition = "electron", command = ["npm", "run", "dist"], source = "release" }
+product-name = "LexEd"
+endpoints = ["gh-release"]
+sign = true
 
 [shipit]
 version = "84818feb7b7c39ebdb5875028828db05b2d65f8a"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## Unreleased
 
+# CI: adopt shipit's composed release pipeline (ADP02-WS09)
+
+The release surface is now declared in `.shipit.toml` (`[artifacts.lexed]`:
+the electron composition — dmg + AppImage + windows Setup.exe, legacy asset
+parity) and dispatched through the blessed `shipit-release.yml` stage-choice
+caller. The darwin leg builds unsigned and is signed/notarized by shipit's
+standalone mac-sign stage (per-code-role JIT entitlements). The upstream
+cascade listener now also accepts shipit's `upstream-release` dispatch type
+alongside the legacy `upstream-released`. The legacy `release.yml` stays
+untouched until the rc proof.
+
 ## 0.11.2 - 2026-06-20
 
 - Expand unit test coverage for keybindings shortcut parser (getShortcutVariants and parseShortcut edge cases)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-# CI: adopt shipit's composed release pipeline (ADP02-WS09)
+### CI: adopt shipit's composed release pipeline (ADP02-WS09)
 
 The release surface is now declared in `.shipit.toml` (`[artifacts.lexed]`:
 the electron composition — dmg + AppImage + windows Setup.exe, legacy asset

--- a/CHANGELOG/unreleased-shipit-release-adoption.md
+++ b/CHANGELOG/unreleased-shipit-release-adoption.md
@@ -1,0 +1,10 @@
+# CI: adopt shipit's composed release pipeline (ADP02-WS09)
+
+The release surface is now declared in `.shipit.toml` (`[artifacts.lexed]`:
+the electron composition — dmg + AppImage + windows Setup.exe, legacy asset
+parity) and dispatched through the blessed `shipit-release.yml` stage-choice
+caller. The darwin leg builds unsigned and is signed/notarized by shipit's
+standalone mac-sign stage (per-code-role JIT entitlements). The upstream
+cascade listener now also accepts shipit's `upstream-release` dispatch type
+alongside the legacy `upstream-released`. The legacy `release.yml` stays
+untouched until the rc proof.

--- a/CHANGELOG/unreleased-shipit-release-adoption.md
+++ b/CHANGELOG/unreleased-shipit-release-adoption.md
@@ -1,4 +1,4 @@
-# CI: adopt shipit's composed release pipeline (ADP02-WS09)
+### CI: adopt shipit's composed release pipeline (ADP02-WS09)
 
 The release surface is now declared in `.shipit.toml` (`[artifacts.lexed]`:
 the electron composition — dmg + AppImage + windows Setup.exe, legacy asset

--- a/app-bin/release-provision.sh
+++ b/app-bin/release-provision.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Self-provisioning for the shipit release BUILD leg (ADP02-WS09, #172).
+#
+# The wf-build block's checkout provisions nothing beyond pixi (no
+# node_modules, no comms submodule, no fetch-deps on PATH — the same
+# bare-runner premise the WS03 lanes' test-full/lint-full tasks
+# self-provision around), so the `[toolchains]` build override
+# (`npm run build:release`, .shipit.toml) runs this script before
+# dispatching to the ordinary `npm run build`. Mirrors what the legacy
+# arthur-debert/release electron-app.yml@v3 workflow provisioned per leg:
+#
+#   - the comms submodule — gen-theme.py's canonical theme data
+#     (comms/shared/theming/lex-theme.json) rides it, and the wf-build
+#     checkout has no submodule support (the shipit#759 pattern);
+#   - `npm ci` root + shared/ — @lex/shared is a `file:./shared` dep with
+#     its own lockfile; each is a clean lockfile-exact reinstall, so a CI
+#     leg and a laptop run are byte-identical (like the test-full lane);
+#   - `fetch-deps` — the stdlib-python dependency fetcher (deps.json:
+#     lexd-lsp binary, grammar WASM) the build script calls by name. It is
+#     not an npm bin, so the legacy workflow curl-provisioned it onto PATH;
+#     here it lands in node_modules/.bin, which `npm run` puts on PATH for
+#     every script (plus the .cmd shim npm/cmd.exe needs on a windows
+#     runner — that leg is blocked on shipit#893 but provisioned for parity).
+set -euo pipefail
+
+git submodule update --init --recursive comms
+
+npm ci
+npm ci --prefix shared
+
+bin_dir="node_modules/.bin"
+curl -fsSL -o "$bin_dir/fetch-deps" \
+	"https://raw.githubusercontent.com/arthur-debert/release/main/bin/fetch-deps"
+chmod +x "$bin_dir/fetch-deps"
+# cmd.exe can't exec a shebang script; route through python explicitly
+# (same shim the legacy electron-app.yml wrote).
+printf '@python "%%~dp0fetch-deps" %%*\r\n' >"$bin_dir/fetch-deps.cmd"

--- a/app-bin/release-provision.sh
+++ b/app-bin/release-provision.sh
@@ -28,7 +28,14 @@ git submodule update --init --recursive comms
 npm ci
 npm ci --prefix shared
 
+# main, not a pinned ref, deliberately (mirrors the legacy electron-app.yml
+# provision step verbatim): consumers track release@main for fetch-deps by
+# design — upstream's CI `guards` job keeps main's bin/fetch-deps a real,
+# working file (arthur-debert/release#317), and upstream fixes (e.g. the
+# CRLF fetch bug, release#507) flow to every consumer without a per-repo
+# pin bump this repo has no mechanism for.
 bin_dir="node_modules/.bin"
+mkdir -p "$bin_dir"
 curl -fsSL -o "$bin_dir/fetch-deps" \
 	"https://raw.githubusercontent.com/arthur-debert/release/main/bin/fetch-deps"
 chmod +x "$bin_dir/fetch-deps"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build:quicklook": "bash ./app-bin/build-quicklook.sh",
     "check-deps": "node ./app-bin/check-deps.mjs",
     "build": "fetch-deps --if-missing && npm run check-deps && tsc && vite build && electron-builder",
+    "build:release": "bash app-bin/release-provision.sh && npm run build",
+    "dist": "electron-builder --publish never",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0",


### PR DESCRIPTION
Closes #172. For arthur-debert/shipit#842 (ADP02-WS09 — lexed is the FIRST consumer fire of the electron bundling composition, shipit#823, and the electron mac sign/notarize path, shipit#833).

Cuts lexed's release path onto shipit's composed pipeline: `[artifacts.lexed]` declarations in `.shipit.toml` plus the `shipit-release.yml` blessed caller ALONGSIDE the untouched legacy `release.yml`. Legacy removal is NOT this PR — it follows the remote rc proof, a later coordinator-driven step.

## What changed

- **`.shipit.toml` → `[artifacts.lexed]`**: the electron composition per shipit#823's decision record — `build = ["npm"]`, three platform legs (`darwin-arm64`, `linux-x86_64`, `windows-x86_64` = the legacy v0.11.0 asset set: `LexEd-<v>-arm64.dmg`+blockmap, `LexEd-<v>.AppImage`, `LexEd.Setup.<v>.exe`+blockmap), `bundle = { composition = "electron", command = ["npm", "run", "dist"], source = "release" }` (`release/` = electron-builder's `directories.output`), `product-name = "LexEd"` (assert-bundle's dmg/AppImage filename fallback tier; the darwin reseal payload's `CFBundleExecutable` is the authoritative tier), `endpoints = ["gh-release"]`, `sign = true` → the darwin leg routes through the STANDALONE mac-sign stage (build unsigned → reopen → resign inner-first with per-code-role JIT entitlements, shipit#833 → reseal dmg → notarize). electron-builder's own signing stays OFF by construction: no CSC_* env rides the build leg, `notarize: false` stays in package.json, and the afterPack appex hook skips without `CSC_LINK`.
- **`[toolchains]` build override + `app-bin/release-provision.sh` + two additive package.json scripts**: the wf-build checkout provisions nothing beyond pixi (no node_modules, no comms submodule, no `fetch-deps` on PATH), the exact bare-runner premise this repo's WS03 lanes already self-provision around — so `build:release` chains provisioning (comms submodule for gen-theme's canonical data, `npm ci` root+shared/, `fetch-deps` curl-provisioned into `node_modules/.bin` — on PATH for every `npm run` script, mirroring what legacy `electron-app.yml@v3` provisioned per leg) into the untouched `npm run build`. `dist` (`electron-builder --publish never`) is the declared bundle command: the build stage already compiled and packaged once, so the bundle-stage run is an idempotent repackage the composition collects from.
- **`.github/workflows/shipit-release.yml`**: shipit's own WS09 blessed stage-choice caller (ADR-0054: five-way `stage` choice, `tag`+`run-id` inputs, `contents: write` + `actions: read`) copied VERBATIM, adapting only (a) the header to lexed facts, (b) the secrets set: `RELEASE_TOKEN` + the electron mac sign set — `APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}` (the caller-boundary mapping from the legacy-named repo secret; NOT renamed — legacy release.yml still consumes it), `APPLE_CERTIFICATE_PASSWORD`, and the ASC trio verbatim — forwarded on `full` and on the standalone `sign` dispatch (wf-sign-mac declares them; shipit's/standout's callers had no sign secrets because their plans carry no mac sign). All five stage choices kept.
- **`on-upstream-released.yml`**: `types: [upstream-released, upstream-release]` — adds shipit's notify-downstreams event type (shipit#824) alongside the legacy v3 cascade type, per the coordinator note on shipit#842. Legacy type retirement belongs to the legacy-cascade retirement, not this cutover.
- **Changelog fragment** added (`CHANGELOG/unreleased-shipit-release-adoption.md`) + rendered `CHANGELOG.md` (`changelog check` green).

## ⚠️ FLAGS (stop-and-flag, not worked around)

1. **Windows leg blocked on shipit#893** (known, from the issue): the `windows-x86_64` leg runs shipit on a windows runner (win-importability fix in flight). Declared per legacy parity as directed; the coordinator sequences the rc proof after #893.
2. **dmg blockmap handling DIFFERS from legacy** (the issue's flag-if-differs case): the composition collects `LexEd-<v>-arm64.dmg.blockmap` at bundle time — generated by electron-builder against the UNSIGNED dmg — but the sign stage reseals a NEW dmg via hdiutil, so the published blockmap will not match the published dmg's bytes. Legacy signed inline at build, so its blockmap matched the shipped dmg. Impact: electron-updater differential updates fall back to full download (or error) on mac; correctness of the shipped app is unaffected. Needs a shipit-side call (regenerate or drop the dmg blockmap at reseal) — coordinator to place on arthur-debert/shipit if differential mac updates matter.
3. **QuickLook `.appex` entitlements gap (shipit-side, #833's declared out-of-scope)**: shipit's signer signs a nested `.appex` with NO entitlements — deliberate (never inherit JIT), but `LexQuickLook.appex` needs `com.apple.security.app-sandbox` (+ user-selected read-only) to load as an app extension. Expect the rc's QuickLook integration to be broken-at-runtime until #833's `appex` policy seam gets a consumer-declarable plist. Signing/notarization of the main app should be unaffected.
4. **Notary secrets**: the plan accepts either notary trio; this repo provisions the ASC trio, forwarded verbatim. Legacy `APPLE_APP_SPECIFIC_PASSWORD` left untouched per the issue (it is the legacy notary alt, still consumed by legacy release.yml); the Apple-ID trio is NOT forwarded (unprovisioned — dead YAML otherwise).
5. **Node version drift, minor**: the shipit build leg runs on pixi's fleet-pinned node 26; legacy pinned 22.18.0 to match the old test.yml. The shipped app runs on bundled Electron regardless; noting for the rc comparison.
6. **Brief-gap flag**: this spawn brief didn't carry the implementer template's slots (named verify commands / governing-docs list / decision boundaries); the ISSUE's Doctrine section was slot-complete (verify: preflight rc+non-rc, wf test prepare dry-run, repo suite, changelog fragment; docs: #823/#833 decision records + the blessed-caller doctrine), so I took them from there — nothing was guessed.

## Verification (run in the Tree, pinned shipit 84818feb)

- `shipit release preflight 0.0.0-release-rc --json --plan-only` → 3-leg matrix (darwin-arm64 sign+bundle, linux-x86_64 bundle, windows-x86_64 bundle), stages `preflight, prepare, bundle, assert-bundle, sign, publish`, endpoints `["gh-release"]`, secrets `RELEASE_TOKEN, APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD` + either notary trio. Non-rc control (`1.0.0`): identical shape (gh-release-only surface — no external endpoint for the rc guard to drop). Presence validation confirmed live: preflight with no env fails loudly naming every missing name; with the full dummy set it exits 0.
- `shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --input version=0.0.0-release-rc --dry-run` → **WF TEST: OK** (act resolves the remote `wf-prepare@v1` chain; job graph green). act-untestable surface (mac sign leg, windows runner) is the rc proof's domain.
- `pixi run test` → **244/244 passed** (18 files).
- `shipit changelog check` green; commit/push hooks ran the full lint suite (ruff, shellcheck/shfmt on the new script, yamllint + actionlint on both workflow files, prettier, markdownlint, lexd) — 9 checks OK.

## Self-check against governing docs

- **shipit#823 decision record**: declaration matches the composition contract — declared-command electron bundle, `source` distinct from the bundle tree, darwin exactly-one-dmg premise holds (mac targets only `dmg`), `sign = true` routes through the standalone stage, blockmap sidecars collected with their primaries.
- **ADR-0040 / workflows.lex §8**: the caller is routing-only — five `uses:` lines, verbatim input forwarding, full remote `@v1` refs, the §8 permissions grant; no companion/fallback workflows, no plan logic consumer-side. The provisioning script is build-surface (the WS03 lane pattern), not workflow wiring.
- **ADR-0041**: `tag` forwarded verbatim to tag-dispatched stages; nothing here computes a version (prepare bumps the manifest projection).
- **ADR-0009**: barrier logic stays in the blocks; every declared leg's primary distributable is hard-required by the composition.
- **WS03 constraints (#168)**: interim `e2e.yml` + `check / e2e` context untouched; lexed#170 stale-dist bug untouched (out of scope).

## Out of scope — do not "fix" here

- Legacy `release.yml` and its secrets (incl. `APPLE_APP_SPECIFIC_PASSWORD`): untouched by design; removal follows the rc proof.
- The `copilot-review.yml` retired unit and the shipit pin (7 behind main): the reconcile PR's domain (ADR-0033).
- No dispatches, no tags, nothing published — the coordinator dispatches the rc proof after merge (and after shipit#893 for the windows leg).
- The `npm run build` script and e2e surface: `build:release`/`dist` are additive; everything legacy/e2e consumes is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)